### PR TITLE
push updated extensions to build files

### DIFF
--- a/.github/workflows/update-extension-release.yaml
+++ b/.github/workflows/update-extension-release.yaml
@@ -14,7 +14,7 @@ jobs:
           ref: 'master'
           repository: 'layer5labs/meshery-extensions'
       - name: Update extensions_releases.json
-        run: rm -f extension_releases.json && curl -s https://api.github.com/repos/layer5labs/meshery-extensions-packages/releases >> extension_releases.json;
+        run: rm -f build/extension_releases.json && curl -s https://api.github.com/repos/layer5labs/meshery-extensions-packages/releases >> build/extension_releases.json;
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
**Description**
Push the changes to `build/` instead of root, because that's how we are managing this `.json` in extension there.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
