### PR TITLE
[Cypress] Cypress visualiser visit test fix| CU-2p7c3cj

### DIFF
--- a/cypress/integration/e2e/login_spec.js
+++ b/cypress/integration/e2e/login_spec.js
@@ -21,14 +21,18 @@ describe("Login", () => {
     cy.contains("Filters")
   });
 
-  // visualizer test is skipped until the gql-plugin error sorts out in Meshery -- Fixed via infinite token.
   it("Visit MeshMap Visualizer", () => {
     cy.setMode(VISUALIZER)
     cy.visit("/extension/meshmap")
     cy.wait("@getCapabilites")
-    cy.wait(15000)
+    cy.intercept("/api/provider/extension*").as("extensionFileLoad")
+    cy.wait("@extensionFileLoad");
+    cy.get("body").then(body => {
+      if (body.find('[data-cy="modal-close-btn"]').length > 0) {
+        cy.get('[data-cy="modal-close-btn"]').click();
+      }
+    })
     cy.contains("MeshMap")
-    cy.contains("View Selector")
     //tabs
     cy.contains("Details")
     cy.contains("Metrics")


### PR DESCRIPTION
Signed-off-by: Gaurav Chadha <gauravchadha1676@gmail.com>

**Description**
Fixes the Visualizer test and removes extra waiting on go plugin load.

This PR fixes #42  CU-2p7c3cj

**Notes for Reviewers**

https://user-images.githubusercontent.com/65453826/191069403-52c4b287-d639-471e-951b-4a02b10326d5.mp4



**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
