### PR TITLE
fix: faliing the renaming a design

### DIFF
--- a/cypress/integration/e2e/design_spec.js
+++ b/cypress/integration/e2e/design_spec.js
@@ -36,12 +36,12 @@ describe("Designer Spec", () => {
     cy.get("#component-drawer-Application").should('be.visible').drag("#cy-canvas-container", {force: true});
     cy.get("[data-cy='design-drawer']").click(); // to close the rjsf form by click event
     cy.intercept('/api/pattern').as('patternSave')
-    cy.get("#design-name-textfield").type("Changed Name with cypress");
+    cy.get("#design-name-textfield").clear().type("Changed Name with cypress");
     cy.wait("@patternSave").then(() => {
       // move to drawer and check for update
       cy.get("[data-cy='design-drawer']").click();
       cy.get("#MUIDataTableBodyRow-patterns-0 p", {timeout: 30000});
-      cy.wait(2000);
+      cy.wait(2500);
       cy.get("#MUIDataTableBodyRow-patterns-0 p").contains("Changed Name with cypress");
     })
   })


### PR DESCRIPTION
Signed-off-by: Abhishek kr <abhimait1909@gmail.com>

**Description**
Clearing the text-field before renaming
Fixes: ⬇️ 
<img width="262" alt="Screenshot 2022-10-10 at 9 00 22 PM" src="https://user-images.githubusercontent.com/48255244/194902479-8941002f-4386-4e80-8c43-a472299be892.png">


This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
