### PR TITLE
[CI] Add workflow to update permissions constants

### DIFF
--- a/.github/actions/permission-constants-updater/main.go
+++ b/.github/actions/permission-constants-updater/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Helper function to convert a string to UPPER_SNAKE_CASE
+func toSnakeCase(str string) string {
+	snake := strings.ReplaceAll(str, " ", "_")
+	snake = strings.ToUpper(snake)
+	return snake
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run main.go <input_csv>")
+		return
+	}
+
+	inputFile := os.Args[1]
+	outputFile := "permission_constants.js"
+
+	// Open the input CSV file
+	f, err := os.Open(inputFile)
+	if err != nil {
+		fmt.Printf("Error opening input file: %v\n", err)
+		return
+	}
+	defer f.Close()
+
+	// Read the CSV file
+	reader := csv.NewReader(f)
+	records, err := reader.ReadAll()
+	if err != nil {
+		fmt.Printf("Error reading CSV file: %v\n", err)
+		return
+	}
+
+	// Check if the CSV file has at least 2 rows (metadata + header)
+	if len(records) < 2 {
+		fmt.Println("CSV file does not contain enough rows")
+		return
+	}
+
+	// Extract header and ensure it has 'Function' and 'Key ID' columns
+	header := records[1] // header is the second row
+	functionIdx, keyIDIdx := -1, -1
+	for i, column := range header {
+		if column == "Function" {
+			functionIdx = i
+		} else if column == "Key ID" {
+			keyIDIdx = i
+		}
+	}
+
+	// Validate that both 'Function' and 'Key ID' columns were found
+	if functionIdx == -1 || keyIDIdx == -1 {
+		fmt.Println("CSV does not contain 'Function' or 'Key ID' columns")
+		return
+	}
+
+	// Open the output JavaScript file
+	output, err := os.Create(outputFile)
+	if err != nil {
+		fmt.Printf("Error creating output file: %v\n", err)
+		return
+	}
+	defer output.Close()
+
+	// Start writing the keys.js content
+	fmt.Fprintln(output, "export const keys = {")
+
+	// Iterate over the data rows (starting from the third row)
+	for _, row := range records[2:] {
+		function := row[functionIdx]
+		keyID := row[keyIDIdx]
+
+		// Skip records with an empty Key ID field
+		if keyID == "" {
+			continue
+		}
+
+		// Convert the function to UPPER_SNAKE_CASE
+		snakeCaseFunction := toSnakeCase(function)
+
+		// Write the object to the output file
+		fmt.Fprintf(output, "  \"%s\": { subject: \"%s\", action: \"%s\" },\n", snakeCaseFunction, function, keyID)
+	}
+
+	// Close the keys object
+	fmt.Fprintln(output, "};")
+
+	fmt.Printf("Successfully generated %s\n", outputFile)
+}

--- a/.github/workflows/permission-constants-updater.yml
+++ b/.github/workflows/permission-constants-updater.yml
@@ -1,0 +1,102 @@
+name: Generate permissions constants
+on:
+  workflow_dispatch:
+    inputs:
+      spreadsheet_uri:
+        description: Link of the spreadsheet containing keys.
+        type: string
+        default: https://docs.google.com/spreadsheets/d/e/2PACX-1vQwzrUSKfuSRcpkp7sJTw1cSB63s4HCjYLJeGPWECsvqn222hjaaONQlN4X8auKvlaB0es3BqV5rQyz/pub?gid=64355745&single=true&output=csv
+jobs:
+  fetch-keys:
+    name: Fetch Keys
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          fetch-depth: 1
+
+      - name: Check out Meshery repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          repository: meshery/meshery
+          path: meshery
+
+      - name: Check out Cloud repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          repository: layer5io/meshery-cloud
+          path: meshery-cloud
+
+      - name: Check out Cloud repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          repository: layer5labs/meshery-extensions
+          path: meshery-extensions
+
+      - name: Set spreadsheet_uri as environment variable
+        run: echo "spreadsheet_uri=https://docs.google.com/spreadsheets/d/e/2PACX-1vQwzrUSKfuSRcpkp7sJTw1cSB63s4HCjYLJeGPWECsvqn222hjaaONQlN4X8auKvlaB0es3BqV5rQyz/pub?gid=64355745&single=true&output=csv" >> $GITHUB_ENV
+        if: inputs.spreadsheet_uri != ''
+          echo "spreadsheet_uri=${{ inputs.spreadsheet_uri }}" >> $GITHUB_ENV
+
+      - name: Dump keys from the spreadsheet
+        run: |
+          curl -L "${{ env.spreadsheet_uri }}" -o "./keys.csv";
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - name: Run Go program to generate permissions_constants.js
+        run: |
+          go run .github/actions/permission-constants-updater/main.go keys.csv
+
+      - name: Copy to Meshery
+        run: |
+          cp permission_constants.js meshery/ui/utils/permission_constants.js
+
+      - name: Commit changes to Meshery
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Updated permissions constants.
+          repository: ./meshery
+          branch: master
+          commit_options: "--signoff"
+          commit_user_name: l5io
+          commit_user_email: ci@layer5.io
+          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>author of the commit that triggered the run
+
+      - name: Copy to Meshery Cloud
+        run: |
+          cp permission_constants.js meshery-cloud/ui/utility/permission_constants.js
+
+      - name: Commit changes to Meshery-Cloud repo
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Updated permissions constants
+          repository: ./meshery-cloud
+          branch: master
+          commit_options: "--signoff"
+          commit_user_name: l5io
+          commit_user_email: ci@layer5.io
+          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>author of the commit that triggered the run
+
+      - name: Copy to Meshery Extensions
+        run: |
+          cp permission_constants.js meshery-extensions/meshmap/src/utils/permission_constants.js
+
+      - name: Commit changes to Meshery Extensions repo
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Updated permissions constants
+          repository: ./meshery-extensions
+          branch: master
+          commit_options: "--signoff"
+          commit_user_name: l5io
+          commit_user_email: ci@layer5.io
+          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>author of the commit that triggered the run


### PR DESCRIPTION
**Description**

A Permission constants file, housing the code monikers for various permissions is shared among various layer5 projects.
Till now, everytime a permission was to be added to the UI, this file needed to be updated manually in all repos, leading to much redundant effort and work. 
This PR adds a workflow that will automatically update the file in all those projects.

It will iterate through the records looking for data two columns particularly:
- Function
- Key ID

then will add them to the keys component as:
`export const keys = {
VALUE_OF_FUNCTION: {
action: "value of Function"
subject: "value of Key ID"
}
}`

**Notes for Reviewers**
This PR will fix https://github.com/meshery/meshery/issues/12080

**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
