### PR TITLE
make kanvas-prod to prod: include all extensions in build

### DIFF
--- a/.github/workflows/extension-test-on-pr.yml
+++ b/.github/workflows/extension-test-on-pr.yml
@@ -95,7 +95,7 @@ jobs:
           node-version: ${{ secrets.NODE_VERSION }}
       - name: Build Meshery Extension UI
         working-directory: ./meshery-extensions
-        run: make kanvas-prod # gql build is not done for now
+        run: make prod # gql build is not done for now
       - name: Build Graphql Plugin
         working-directory: ./meshery-extensions
         run: make graphql


### PR DESCRIPTION
Signed-off-by: Lee Calcote <lee.calcote@layer5.io>

**Description**

This PR builds all extensions, not just Kanvas.




**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
