### PR TITLE
ci: add rtk codegen on production built

### DIFF
--- a/.github/workflows/meshery-cloud-build-reusable.yml
+++ b/.github/workflows/meshery-cloud-build-reusable.yml
@@ -43,15 +43,6 @@ jobs:
   build-meshery-cloud:
     runs-on: ubuntu-latest
     steps:
-      - name: comment progress
-        uses: hasura/comment-progress@v2.3.0
-        with:
-          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
-          repository: "layer5io/meshery-cloud"
-          number: ${{ inputs.pr_number }}
-          id: meshery-cloud
-          message: ":heavy_check_mark: Meshery UI and Meshery Server builds complete."
-          append: true
       - name: Checkout Meshery Cloud code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/meshery-cloud-release.yml
+++ b/.github/workflows/meshery-cloud-release.yml
@@ -131,10 +131,20 @@ jobs:
         token: ${{ secrets.GH_ACCESS_TOKEN }}
         ref: ${{ inputs.branch }}
     - name: Build Docs
+      working-directory: meshery-cloud
       run:  |
-        cd meshery-cloud
         npm i -g @redocly/cli@latest
         make docs-build
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+    - name: Setup UI Dependencies
+      working-directory: meshery-cloud
+      run: make ui-setup
+    - name: Build RTK Query Codegen
+      working-directory: meshery-cloud
+      run: make ui-api-codegen
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -203,11 +213,20 @@ jobs:
         path: meshery-cloud
         fetch-depth: 1
         token: ${{ secrets.GH_ACCESS_TOKEN }}
+    - name: Build RTK Query Codegen
+      working-directory: meshery-cloud
+      run: make ui-api-codegen
     - name: Build Docs
+      working-directory: meshery-cloud
       run:  |
-        cd meshery-cloud
         npm i -g @redocly/cli@latest
         make docs-build
+    - name: Setup UI Dependencies
+      working-directory: meshery-cloud
+      run: make ui-setup
+    - name: Build RTK Query Codegen
+      working-directory: meshery-cloud
+      run: make ui-api-codegen
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx

--- a/.github/workflows/meshery-cloud-release.yml
+++ b/.github/workflows/meshery-cloud-release.yml
@@ -213,9 +213,6 @@ jobs:
         path: meshery-cloud
         fetch-depth: 1
         token: ${{ secrets.GH_ACCESS_TOKEN }}
-    - name: Build RTK Query Codegen
-      working-directory: meshery-cloud
-      run: make ui-api-codegen
     - name: Build Docs
       working-directory: meshery-cloud
       run:  |


### PR DESCRIPTION
**Description**

It's seems we are missing rtk-query build from the open api schema on production but used the old one, which are not being generated for long time

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
