### PR TITLE
Rename file version of testresults with ` _`

### DIFF
--- a/.github/workflows/extension-test-relationship.yml
+++ b/.github/workflows/extension-test-relationship.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       checkout_ref: "master"
       test_command: "make test-relationship"
+
   update-meshery-test-relationship-report:
     name: Update meshery test relationship report
     needs: [meshery-extensions-test-relationship]
@@ -24,6 +25,14 @@ jobs:
       with:
         name: relationship-playwright-report
         path: meshery-extensions/meshmap/
+
+    - name: Rename file version with underscore
+      run: |
+        for file in meshery-extensions/meshmap/relationship-*.json; do
+          new_file=$(echo "$file" | sed 's/\./_/g' | sed 's/_json/.json/')
+          mv "$file" "$new_file"
+        done
+
     - name: Check out Meshery code
       uses: actions/checkout@v4
       with:
@@ -31,6 +40,7 @@ jobs:
         token: ${{ secrets.RELEASEDRAFTER_PAT }} 
         fetch-depth: 1
         path: meshery
+
     - name: Create target directory if not exist
       run: mkdir -p meshery/docs/_data/relationshiptestresult
 
@@ -51,4 +61,3 @@ jobs:
         commit_user_name: l5io
         commit_user_email: ci@layer5.io
         commit_author: 'l5io <l5io@users.noreply.github.com>'
-      


### PR DESCRIPTION
**Description**

Since jekyll doesn't support `.` in file name because are treated as path separators thats why in this pr i am replacing `.` in the file version name with `_`  after downloading the artifacts and before moving the file to the target directory.

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
