### PR TITLE
fix stretched kanvas and badges issue

### DIFF
--- a/site/src/sitecomponents/BadgeGrid/Badges.styles.js
+++ b/site/src/sitecomponents/BadgeGrid/Badges.styles.js
@@ -23,6 +23,7 @@ export const BadgesWrapper = styled.div`
       > img {
         max-width: 250px;
         min-height: 360px;
+        object-fit: contain;
       }
     }
 


### PR DESCRIPTION
**Description**

This PR fixes #

Before: 
![image](https://github.com/user-attachments/assets/34695fe1-5567-4b1f-ab9d-881a4332ac00)

After: 
![image](https://github.com/user-attachments/assets/6d2c0e3b-95e8-4f9c-8482-a04bb6067ed2)


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
