### PR TITLE
reference v4 rather than fixing to 4.4.3 for github-pages-deploy-action

### DIFF
--- a/.github/workflows/build-and-deploy-site.yml
+++ b/.github/workflows/build-and-deploy-site.yml
@@ -24,7 +24,7 @@ jobs:
           make build
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: site # The branch the action should deploy to.
           folder: site/public # The folder the action should deploy.


### PR DESCRIPTION
**Description**

- To fix sudden site deployment failures

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
