### PR TITLE
Fix: Provide a HyperLink to Open the Embedded Design

### DIFF
--- a/meshery-design-embed/README.md
+++ b/meshery-design-embed/README.md
@@ -29,10 +29,8 @@ function Design() {
 
 Props:
  - embedScriptSrc: "Relative path to the exported design"
- - embedId: "Emebedded design id"
- - style: "Custom styles to the embeded design E.g. backgroundColor, textColor, etc"
- - enableLink (optional): Show or hide the “Open in Meshery” button. Default: true
- - host (optional): Target Meshery system. Default: https://cloud.layer5.io
+ - designLink: "Full URL to the embedded design (if provided, shows 'Open in Meshery' button)"
+ - style: "Custom styles to the embedded design E.g. backgroundColor, textColor, etc"
 
 ### Limitations
 

--- a/meshery-design-embed/lib/main.jsx
+++ b/meshery-design-embed/lib/main.jsx
@@ -33,25 +33,20 @@ const useScript = (url, embedId) => {
 
 const MesheryDesignEmbed = ({
   embedScriptSrc,
-  embedId,
-  host = "https://cloud.layer5.io",
-  enableLink = true,
+  designLink,
   style = {},
 }) => {
-  useScript(embedScriptSrc, embedId);
+  useScript(embedScriptSrc, designLink);
 
-  const link = embedId
-    ? `${host}/designer?designId=${embedId}`
-    : host;
   return (
     <div style={{ width: "100%", height: "30rem", ...style }}>
       {/* Embed script injection (iframe or script tag logic here) */}
-      <div id={embedId}></div>
+      <div id={designLink}></div>
 
-      {/* Optional Open button */}
-      {enableLink && (
+      {/* Show button only if designLink exists */}
+      {designLink && (
         <div style={{ marginTop: "1rem" }}>
-          <a href={link} target="_blank" rel="noopener noreferrer">
+          <a href={designLink} target="_blank" rel="noopener noreferrer">
             <button>Open in Meshery</button>
           </a>
         </div>

--- a/meshery-design-embed/src/App.jsx
+++ b/meshery-design-embed/src/App.jsx
@@ -8,13 +8,8 @@ function App() {
   // By default, this embed points to https://meshery.layer5.io.
   // To change the destination, modify the host or designId below.
 
-  const host = "https://cloud.layer5.io/catalog/content/design";
-  const designId = "embedded-design-a95b76ce-ceaf-4bdf-bac7-95a6773168cd";
+  const designLink = "https://cloud.layer5.io/catalog/content/design/embedded-design-a95b76ce-ceaf-4bdf-bac7-95a6773168cd";
 
-  // if designId exists, append it to the URL
-  const link = designId
-    ? `${host}/${designId}`
-    : host;
   return (
     <>
       <h3> Test Rerenders </h3>
@@ -22,18 +17,10 @@ function App() {
       <p>{count}</p>
 
       <h3>Meshery Embed</h3>
-      <div>
-        <MesheryDesignEmbed
-          embedScriptSrc="embedded-design-embed1.js"
-          embedId={designId}
-        />
-      </div>
-      
-      <div style={{ marginTop: "1rem" }}>
-        <a href={link} target="_blank" rel="noopener noreferrer">
-          <button>Open in Meshery</button>
-        </a>
-      </div>  
+      <MesheryDesignEmbed
+        embedScriptSrc="embedded-design-embed1.js"
+        designLink={designLink}
+      />
     </>
   );
 }


### PR DESCRIPTION
**Description**

This PR fixes #297 
const designLink 

**Notes for Reviewers**

- This change is **limited to the React wrapper only**.
- The underlying embed script (`embedded-design-embed1.js`) is not modified

**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
