### PR TITLE
Added "View" & "Clone" Modes for Meshery Embedded Designs

### DIFF
--- a/meshery-design-embed/lib/main.jsx
+++ b/meshery-design-embed/lib/main.jsx
@@ -34,9 +34,88 @@ const useScript = (url, embedId) => {
 const MesheryDesignEmbed = ({
   embedScriptSrc,
   designLink,
+  mode = "open",
   style = {},
 }) => {
   useScript(embedScriptSrc, designLink);
+
+  // Extract design ID from designLink URL
+  const extractDesignId = (url) => {
+    if (!url) return null;
+    const match = url.match(/design\/([^/?]+)/);
+    return match ? match[1] : null;
+  };
+
+  const designId = extractDesignId(designLink);
+  const baseUrl = designLink ? new URL(designLink).origin : null;
+
+  // Check if user is logged in (placeholder - implement based on your auth system)
+  const isLoggedIn = () => {
+    // This should be replaced with actual auth check
+    // e.g., check localStorage, cookies, or call auth API
+    return localStorage.getItem('meshery_auth_token') !== null;
+  };
+
+  // Handle Open mode - Open Original
+  const handleOpen = () => {
+    if (!isLoggedIn()) {
+      // Redirect to login with return URL
+      const returnUrl = encodeURIComponent(designLink);
+      const loginUrl = `${baseUrl}/login?returnUrl=${returnUrl}`;
+      window.open(loginUrl, '_blank');
+    } else {
+      // Already logged in, open directly
+      window.open(designLink, '_blank');
+    }
+  };
+
+  // Handle Clone mode - Create and Open Independent Copy
+  const handleClone = async () => {
+    try {
+      if (!designId || !baseUrl) {
+        console.error('Missing design ID or base URL');
+        return;
+      }
+
+      // POST to clone API
+      const response = await fetch(`${baseUrl}/api/designs/${designId}/clone`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          // Add auth headers if needed
+          // 'Authorization': `Bearer ${localStorage.getItem('meshery_auth_token')}`
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Clone failed: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      const newDesignId = data.newDesignId || data.id;
+
+      if (!newDesignId) {
+        throw new Error('No new design ID returned from clone API');
+      }
+
+      // Extract design name and create new link
+      const urlParams = new URL(designLink).searchParams;
+      const designName = urlParams.get('name') || 'design';
+      const newDesignName = `${designName}-copy`;
+
+      // Create new link (example format from your description)
+      const newLink = `${baseUrl}/extension/meshmap?mode=design&type=design&id=${newDesignId}&name=${newDesignName}`;
+      
+      window.open(newLink, '_blank');
+    } catch (error) {
+      console.error('Error cloning design:', error);
+      alert('Failed to clone design. Please try again.');
+    }
+  };
+
+  // Determine button text and handler based on mode
+  const buttonText = mode === 'clone' ? 'Clone in Meshery' : 'Open in Meshery';
+  const handleButtonClick = mode === 'clone' ? handleClone : handleOpen;
 
   return (
     <div style={{ width: "100%", height: "30rem", ...style }}>
@@ -46,9 +125,9 @@ const MesheryDesignEmbed = ({
       {/* Show button only if designLink exists */}
       {designLink && (
         <div style={{ marginTop: "1rem" }}>
-          <a href={designLink} target="_blank" rel="noopener noreferrer">
-            <button>Open in Meshery</button>
-          </a>
+          <button onClick={handleButtonClick}>
+            {buttonText}
+          </button>
         </div>
       )}
     </div>

--- a/meshery-design-embed/src/App.jsx
+++ b/meshery-design-embed/src/App.jsx
@@ -16,14 +16,21 @@ function App() {
       <button onClick={() => setCount(count + 1)}>Click</button>
       <p>{count}</p>
 
-      <h3>Meshery Embed</h3>
+      <h3>Meshery Embed - Open Mode (Open Original)</h3>
       <MesheryDesignEmbed
         embedScriptSrc="embedded-design-embed1.js"
         designLink={designLink}
+        mode="open"
+      />
+
+      <h3>Meshery Embed - Clone Mode (Create Independent Copy)</h3>
+      <MesheryDesignEmbed
+        embedScriptSrc="embedded-design-embed1.js"
+        designLink={designLink}
+        mode="clone"
       />
     </>
   );
 }
-
 
 export default App;

--- a/meshery-design-embed/src/App.jsx
+++ b/meshery-design-embed/src/App.jsx
@@ -6,7 +6,7 @@ function App() {
 
   // Meshery Embed Note:
   // By default, this embed points to https://meshery.layer5.io.
-  // To change the destination, modify the host or designId below.
+  // To change the destination, modify the designLink below.
 
   const designLink = "https://cloud.layer5.io/catalog/content/design/embedded-design-a95b76ce-ceaf-4bdf-bac7-95a6773168cd";
 


### PR DESCRIPTION
**Description**

This PR fixes #524

**Notes for Reviewers**
- Expect Flow:
  - `Open` (`View`)  → Open the Original in Meshery
	- Check login/permissions
            - Not logged in → Redirect to login page (with return URL)
            - Logged in → Redirect directly
            
  -  `Clone`  → Create and Open Independent Copy in Meshery
	  1.	POST /api/designs/{designId}/clone
	  2.	Return newDesignId
	  3.	Redirect to new link (e.g.,https://playground.meshery.io/extension/meshmap?mode=design&type=design&id=960764f6-1865-4275-9e9a-8d24c0731388&name=kubernetes-service-traffic-distribution-copy)<img width="1550" height="737" alt="Screenshot 2025-08-14 at 7 10 56 PM" src="https://github.com/user-attachments/assets/4c99b28f-2aab-4732-b709-cf233d86d775" />

**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
