### PR TITLE
Update readme instructions for Meshery-design-embed

### DIFF
--- a/meshery-design-embed/README.md
+++ b/meshery-design-embed/README.md
@@ -1,10 +1,31 @@
 # Meshery Design Embed Package
 
 Meshery Design Embedding allows you to export a design in a format that can be integrated into websites, blogs, or platforms supporting HTML, CSS, and JavaScript. This embedded version offers an interactive representation of the design, simplifying sharing with infrastructure stakeholders.
+
+## Local Development 
+
+Follow the steps below to setup the local development server and run it locally.
+
+### Install dependencies:
+
+This would install all the packages required.
+
+``` 
+npm i
+```
+### Start the development server:
+
+```
+npm run dev
+```
+
+Open your browser and navigate to http://localhost:5173 
+
+A test design will be automatically rendered, allowing you to see your changes in real-time and test different configurations. The development server supports hot reload, so changes will update automatically.
   
 ## meshery-design-embed react component
 
-This component is meant to facilate the usage of meshery embeddings inside react and its frameworks
+This component is meant to facilitate the usage of meshery embeddings inside react and its frameworks
 
 Usage :
 ```

--- a/meshery-design-embed/src/main.jsx
+++ b/meshery-design-embed/src/main.jsx
@@ -1,10 +1,10 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import App from "./App.jsx";
 
-ReactDOM.render(
-    <React.StrictMode>
-        <App />
-    </React.StrictMode>,
-    document.getElementById("root")
+const root = createRoot(document.getElementById("root"));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
 );


### PR DESCRIPTION
… deprecated code in main.jsx

**Description**

This PR fixes #
It adds instructions for local development server setup inside the /meshery-design-embed.
It also updates the depreciated code in main.jsx. 
`ReactDOM.render()` this method was depreciated in react 18 replaced it with `createRoot `

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
