### PR TITLE
feat: add anchor links to badge sections

### DIFF
--- a/site/src/sitecomponents/BadgeGrid/Badges.styles.js
+++ b/site/src/sitecomponents/BadgeGrid/Badges.styles.js
@@ -1,5 +1,76 @@
 import styled from "styled-components";
 export const BadgesWrapper = styled.div`
+  .badge-section-heading {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 3rem 0 1.5rem;
+    scroll-margin-top: 6rem;
+    flex-wrap: wrap;
+
+    h2 {
+      margin: 0;
+      font-size: 2rem;
+      color: ${({ theme }) => theme.text};
+    }
+
+    .heading-anchor {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.25rem;
+      border: none;
+      background: transparent;
+      color: ${({ theme }) => theme.text};
+      border-radius: 0.375rem;
+      opacity: 0;
+      cursor: pointer;
+      transition: opacity 0.2s ease, color 0.2s ease, background 0.2s ease;
+    }
+
+    &:hover .heading-anchor,
+    &:focus-within .heading-anchor {
+      opacity: 1;
+    }
+
+    .heading-anchor:hover {
+      color: ${({ theme }) => theme.primary || '#00b39f'};
+      background-color: rgba(0, 179, 159, 0.08);
+    }
+
+    .heading-anchor:focus-visible {
+      outline: 2px solid currentColor;
+      outline-offset: 2px;
+      opacity: 1;
+    }
+
+    .copy-feedback {
+      font-size: 0.875rem;
+      color: ${({ theme }) => theme.primary || '#00b39f'};
+      opacity: 0;
+      transform: translateY(4px);
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    .copy-feedback.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+  }
+
   div.badge-grid {
     display: flex;
     flex-wrap: wrap;
@@ -51,6 +122,20 @@ export const BadgesWrapper = styled.div`
   @media (max-width: 670px) {
     div.badge-grid > div {
       max-width: 95%;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .badge-section-heading {
+      gap: 0.5rem;
+
+      .heading-anchor {
+        opacity: 1;
+      }
+
+      .copy-feedback {
+        width: 100%;
+      }
     }
   }
 `;

--- a/site/src/sitecomponents/BadgeGrid/index.js
+++ b/site/src/sitecomponents/BadgeGrid/index.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { FiLink } from 'react-icons/fi';
 import CertificationProgram from "../../../static/assets/badges/certification-program/certification-program.png";
 import MeshMasterCertified from "../../../static/assets/badges/meshmaster-certified/meshmaster-certified.png";
 import CertifiedMesheryContributor from "../../../static/assets/badges/certified-meshery-contributor/certified-meshery-contributor.png";
@@ -10,10 +11,121 @@ import CertifiedMesheryDeveloper from "../../../static/assets/badges/certified-m
 import BadgesWrapper from './Badges.styles';
 const jsonData = require('../../badgesInfo.json');
 
+const SectionHeading = ({ id, title, onCopy, feedback }) => {
+  const isActive = feedback?.id === id;
+  const message =
+    isActive && feedback?.status === 'copied'
+      ? 'Link copied!'
+      : isActive && feedback?.status === 'link-ready'
+        ? 'Link ready!'
+        : '\u00A0';
+
+  return (
+    <div className="badge-section-heading" id={id}>
+      <h2>{title}</h2>
+      <button
+        type="button"
+        className="heading-anchor"
+        onClick={() => onCopy(id)}
+        aria-label={`Copy link to ${title}`}
+        title="Copy link to this section"
+      >
+        <FiLink aria-hidden="true" size={18} />
+        <span className="sr-only">Copy link to {title}</span>
+      </button>
+      <span
+        className={`copy-feedback ${isActive ? 'visible' : ''}`}
+        role="status"
+        aria-live="polite"
+      >
+        {message}
+      </span>
+    </div>
+  );
+};
+
+const copyTextToClipboard = async (text) => {
+  if (typeof navigator !== 'undefined' && navigator?.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      // fall back to legacy method if available
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    try {
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      textArea.setAttribute('readonly', '');
+      textArea.style.position = 'absolute';
+      textArea.style.left = '-9999px';
+      document.body.appendChild(textArea);
+      textArea.select();
+      const result = document.execCommand('copy');
+      document.body.removeChild(textArea);
+      return result;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  return false;
+};
+
 const Footer = () => {
+  const [copyFeedback, setCopyFeedback] = useState({ id: null, status: null });
+  const feedbackTimeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimeoutRef.current) {
+        clearTimeout(feedbackTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const showFeedback = useCallback((id, status) => {
+    setCopyFeedback({ id, status });
+    if (feedbackTimeoutRef.current) {
+      clearTimeout(feedbackTimeoutRef.current);
+    }
+    feedbackTimeoutRef.current = setTimeout(
+      () => setCopyFeedback({ id: null, status: null }),
+      2000
+    );
+  }, []);
+
+  const handleCopyLink = useCallback(
+    async (id) => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const { origin, pathname } = window.location;
+      const url = `${origin}${pathname}#${id}`;
+      const copied = await copyTextToClipboard(url);
+
+      showFeedback(id, copied ? 'copied' : 'link-ready');
+
+      try {
+        window.history.replaceState(null, '', `#${id}`);
+      } catch (error) {
+        window.location.hash = id;
+      }
+    },
+    [showFeedback]
+  );
+
   return (
     <BadgesWrapper>
-      <h2>Special Edition Badges</h2>
+      <SectionHeading
+        id="special-edition-badges"
+        title="Special Edition Badges"
+        onCopy={handleCopyLink}
+        feedback={copyFeedback}
+      />
       <div className="badge-grid">
         {jsonData.specialEditionBadges.map((badge) => {
           return (
@@ -27,7 +139,12 @@ const Footer = () => {
         })}
       </div>
 
-      <h2>Achievement Badges</h2>
+      <SectionHeading
+        id="achievement-badges"
+        title="Achievement Badges"
+        onCopy={handleCopyLink}
+        feedback={copyFeedback}
+      />
       <div className="badge-grid">
         {jsonData.achievementBadges.map((badge) => {
           return (
@@ -41,7 +158,12 @@ const Footer = () => {
         })}
       </div>
 
-      <h2>Project Badges</h2>
+      <SectionHeading
+        id="project-badges"
+        title="Project Badges"
+        onCopy={handleCopyLink}
+        feedback={copyFeedback}
+      />
 
       <div className="badge-grid">
         {jsonData.projectBadges.map((badge) => {
@@ -52,39 +174,61 @@ const Footer = () => {
               <span className="badge-label">{badge.label}</span>
               <p dangerouslySetInnerHTML={{__html: badge.description}}></p>
             </div>
-          );
+         );
        })}
       </div>
-     
-<h2 id="certification">Certification Badges</h2>
-    <div className="badge-grid">
+
+      <SectionHeading
+        id="certification-badges"
+        title="Certification Badges"
+        onCopy={handleCopyLink}
+        feedback={copyFeedback}
+      />
+      <div className="badge-grid">
         <div>
-        <img src={CertifiedMesheryContributor} alt="Certified Meshery Contributor badge" />
-          <span>Certified Meshery Contributor</span> <p>This certificate is recognizes individuals who have demonstrated a clear understanding of each major Meshery architectural component, the frameworks, and the process of contribution.</p>
+          <img src={CertifiedMesheryContributor} alt="Certified Meshery Contributor badge" />
+          <span>Certified Meshery Contributor</span>
+          <p>
+            This certificate is recognizes individuals who have demonstrated a clear understanding of each major Meshery architectural component, the frameworks, and the process of contribution.
+          </p>
         </div>
         <div>
-        <img src={CertifiedMesheryDeveloper} alt="Certified Meshery Developer badge" />
-          <span>Certified Meshery Developer</span> <p>This certificate is recognizes individuals who have demonstrated a clear understanding of each major Meshery architectural component, the frameworks, and the process of contribution.</p>
+          <img src={CertifiedMesheryDeveloper} alt="Certified Meshery Developer badge" />
+          <span>Certified Meshery Developer</span>
+          <p>
+            This certificate is recognizes individuals who have demonstrated a clear understanding of each major Meshery architectural component, the frameworks, and the process of contribution.
+          </p>
         </div>
         <div>
-        <img src={CertifiedMesheryAssociate} alt="Certified Meshery Associate badge" />
-          <span>Certified Meshery Associate</span> <p>This entry-level certification validates a foundational knowledge of Meshery's core concepts and working knowledge of all major functional components.</p>
+          <img src={CertifiedMesheryAssociate} alt="Certified Meshery Associate badge" />
+          <span>Certified Meshery Associate</span>
+          <p>
+            This entry-level certification validates a foundational knowledge of Meshery&apos;s core concepts and working knowledge of all major functional components.
+          </p>
         </div>
         <div>
-        <img src={CertifiedMesheryProfessional} alt="Certified Meshery Professional badge" />
-          <span>Certified Meshery Professional</span> <p>This professional-level certification validates the practical ability to use Meshery for real-world infrastructure design, provisioning, and performance management.</p>
+          <img src={CertifiedMesheryProfessional} alt="Certified Meshery Professional badge" />
+          <span>Certified Meshery Professional</span>
+          <p>
+            This professional-level certification validates the practical ability to use Meshery for real-world infrastructure design, provisioning, and performance management.
+          </p>
         </div>
         <div>
-        <img src={CertifiedMesheryExpert} alt="Certified Meshery Expert badge" />
-          <span>Certified Meshery Expert</span> <p>This advanced-level certification validates deep expertise in operating, troubleshooting, and extending the Meshery platform through systems integration.</p>
+          <img src={CertifiedMesheryExpert} alt="Certified Meshery Expert badge" />
+          <span>Certified Meshery Expert</span>
+          <p>
+            This advanced-level certification validates deep expertise in operating, troubleshooting, and extending the Meshery platform through systems integration.
+          </p>
         </div>
         {/* <div>
-        <img src={MeshMasterCertified} alt="Layer5 badges" />
-          <span>MeshMaster</span> <p>This badge is awarded to individuals who have demonstrated a clear and holistic understanding of cloud native infrastructure management.</p>
+          <img src={MeshMasterCertified} alt="Layer5 badges" />
+          <span>MeshMaster</span>
+          <p>This badge is awarded to individuals who have demonstrated a clear and holistic understanding of cloud native infrastructure management.</p>
         </div>
         <div>
-        <img src={CertificationProgram} alt="Layer5 badges" />
-          <span>Coming Soon...</span> <p>Additional certications are coming soon!</p>
+          <img src={CertificationProgram} alt="Layer5 badges" />
+          <span>Coming Soon...</span>
+          <p>Additional certifications are coming soon!</p>
         </div> */}
       </div>
     </BadgesWrapper>


### PR DESCRIPTION
## Summary
- add shareable anchors to each badge section
- show a link icon with copy-to-clipboard feedback
- adjust styles and verify gatsby build

## Testing
- npm run build

Closes #545.