### PR TITLE
Fix duplicate GH_ACCESS_TOKEN in workflow

### DIFF
--- a/.github/workflows/meshery-cloud-on-pr.yml
+++ b/.github/workflows/meshery-cloud-on-pr.yml
@@ -21,7 +21,6 @@ jobs:
       CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}
       NODE_VERSION: ${{secrets.NODE_VERSION}}
       GH_ACCESS_TOKEN: ${{secrets.GH_ACCESS_TOKEN}}
-      GH_ACCESS_TOKEN: ${{secrets.GH_ACCESS_TOKEN}}
       METAL05_HOST: ${{secrets.METAL05_HOST}}
       METAL_KEY: ${{secrets.METAL_KEY}}
       METAL_USERNAME: ${{secrets.METAL_USERNAME}}


### PR DESCRIPTION
Removed duplicate GH_ACCESS_TOKEN environment variable.

Signed-off-by: Lee Calcote <lee.calcote@layer5.io>