### PR TITLE
ci(tests): derive shard count from runtime instead of hardcoding 4

### DIFF
--- a/.github/workflows/extension-test-reusable.yml
+++ b/.github/workflows/extension-test-reusable.yml
@@ -128,7 +128,7 @@ jobs:
           repository: layer5labs/meshery-extensions
           number: ${{ inputs.pr_number }}
           id: extension-test
-          message: ":heavy_check_mark: Setting up test environment (sharded 1/4..4/4)..."
+          message: ":heavy_check_mark: Setting up test environment (sharded across ${{ strategy.job-total }} runners)..."
           append: true
       - name: Set pending commit status
         if: ${{ inputs.head_sha != '' && matrix.shard == 1 }}
@@ -143,7 +143,7 @@ jobs:
               sha: '${{ inputs.head_sha }}',
               state: 'pending',
               context: 'Meshery Extension E2E Tests',
-              description: 'Tests are running (4 shards)...',
+              description: 'Tests are running (${{ strategy.job-total }} shards)...',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
 
@@ -344,6 +344,9 @@ jobs:
             fi
           done
           echo "overall=$overall" >> "$GITHUB_OUTPUT"
+          # Derive shard count from actual runtime data so user-facing messages
+          # stay in sync with the matrix definition without a second source of truth.
+          echo "count=${#shard_outcome_files[@]}" >> "$GITHUB_OUTPUT"
 
       - name: Collect per-shard reports
         id: test_reports
@@ -396,7 +399,7 @@ jobs:
           message: |
             ### Test Results
 
-            **Meshery:** `stable-latest` | **Shards:** 4 | **Overall:** ${{ steps.aggregate.outputs.overall }}
+            **Meshery:** `stable-latest` | **Shards:** ${{ steps.aggregate.outputs.count }} | **Overall:** ${{ steps.aggregate.outputs.overall }}
 
             ${{ steps.test_reports.outputs.result }}
 
@@ -480,7 +483,7 @@ jobs:
             const stateMap = { success: 'success', failure: 'failure', cancelled: 'error' };
             const state = stateMap[outcome] || 'error';
             const descMap = {
-              success: 'All tests passed across 4 shards',
+              success: 'All tests passed across ${{ steps.aggregate.outputs.count }} shards',
               failure: 'One or more tests failed',
               cancelled: 'Run was cancelled',
             };

--- a/.github/workflows/extension-test-reusable.yml
+++ b/.github/workflows/extension-test-reusable.yml
@@ -118,8 +118,18 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
+    # Expose the matrix size so the non-matrix summary job can report the
+    # configured shard count even if some shards never produced an outcome
+    # marker (runner crash, timeout, cancelled artifact upload). Every shard
+    # writes the same value; GitHub collects whichever one lands.
+    outputs:
+      shard_count: ${{ steps.shard_meta.outputs.shard_count }}
 
     steps:
+      - name: Record shard count
+        id: shard_meta
+        run: echo "shard_count=${{ strategy.job-total }}" >> "$GITHUB_OUTPUT"
+
       - name: comment progress start
         if: ${{ inputs.pr_number != '' && matrix.shard == 1 }}
         uses: hasura/comment-progress@v2.3.0
@@ -399,7 +409,7 @@ jobs:
           message: |
             ### Test Results
 
-            **Meshery:** `stable-latest` | **Shards:** ${{ steps.aggregate.outputs.count }} | **Overall:** ${{ steps.aggregate.outputs.overall }}
+            **Meshery:** `stable-latest` | **Shards:** ${{ needs.tests-ui-e2e.outputs.shard_count != '' && needs.tests-ui-e2e.outputs.shard_count || steps.aggregate.outputs.count }} | **Overall:** ${{ steps.aggregate.outputs.overall }}
 
             ${{ steps.test_reports.outputs.result }}
 
@@ -483,7 +493,7 @@ jobs:
             const stateMap = { success: 'success', failure: 'failure', cancelled: 'error' };
             const state = stateMap[outcome] || 'error';
             const descMap = {
-              success: 'All tests passed across ${{ steps.aggregate.outputs.count }} shards',
+              success: 'All tests passed across ${{ needs.tests-ui-e2e.outputs.shard_count != '' && needs.tests-ui-e2e.outputs.shard_count || steps.aggregate.outputs.count }} shards',
               failure: 'One or more tests failed',
               cancelled: 'Run was cancelled',
             };

--- a/.github/workflows/extension-test-reusable.yml
+++ b/.github/workflows/extension-test-reusable.yml
@@ -354,8 +354,10 @@ jobs:
             fi
           done
           echo "overall=$overall" >> "$GITHUB_OUTPUT"
-          # Derive shard count from actual runtime data so user-facing messages
-          # stay in sync with the matrix definition without a second source of truth.
+          # Fallback shard count from the number of outcome markers collected.
+          # The primary source is needs.tests-ui-e2e.outputs.shard_count (from
+          # strategy.job-total); this covers the edge case where that output is
+          # empty (e.g. all matrix legs cancelled before step 1 ran).
           echo "count=${#shard_outcome_files[@]}" >> "$GITHUB_OUTPUT"
 
       - name: Collect per-shard reports
@@ -409,7 +411,7 @@ jobs:
           message: |
             ### Test Results
 
-            **Meshery:** `stable-latest` | **Shards:** ${{ needs.tests-ui-e2e.outputs.shard_count != '' && needs.tests-ui-e2e.outputs.shard_count || steps.aggregate.outputs.count }} | **Overall:** ${{ steps.aggregate.outputs.overall }}
+            **Meshery:** `stable-latest` | **Shards:** ${{ needs.tests-ui-e2e.outputs.shard_count || steps.aggregate.outputs.count }} | **Overall:** ${{ steps.aggregate.outputs.overall }}
 
             ${{ steps.test_reports.outputs.result }}
 
@@ -493,7 +495,7 @@ jobs:
             const stateMap = { success: 'success', failure: 'failure', cancelled: 'error' };
             const state = stateMap[outcome] || 'error';
             const descMap = {
-              success: 'All tests passed across ${{ needs.tests-ui-e2e.outputs.shard_count != '' && needs.tests-ui-e2e.outputs.shard_count || steps.aggregate.outputs.count }} shards',
+              success: 'All tests passed across ${{ needs.tests-ui-e2e.outputs.shard_count || steps.aggregate.outputs.count }} shards',
               failure: 'One or more tests failed',
               cancelled: 'Run was cancelled',
             };


### PR DESCRIPTION
## Summary

Follow-up to layer5labs/meshery-extensions-packages#687 (already merged). Addresses the six `copilot-pull-request-reviewer` review comments flagging `4` hard-coded in multiple user-facing strings — they arrived after the PR had merged, so could not be fixed in place.

- Matrix job progress comment and pending commit status description now use `${{ strategy.job-total }}` — self-derived from the actual matrix size.
- `tests-ui-e2e-summary` aggregate step now exports `count` based on the number of shard outcome marker files it finds, and the summary PR comment + final commit status description reference `${{ steps.aggregate.outputs.count }}`.
- Matrix definition (`shard: [1, 2, 3, 4]`) is now the single source of truth; every user-facing message is derived from runtime state rather than duplicated literals.

No behaviour change: outputs are identical when the matrix has 4 shards. If/when the matrix list is ever resized, every user-facing message stays in sync automatically.

## Test plan

- [ ] Dispatch `extension-test-on-pr.yml` and confirm progress comment reads "sharded across 4 runners"
- [ ] Confirm the pending commit status reads "Tests are running (4 shards)..."
- [ ] Confirm the summary PR comment header reads "**Shards:** 4"
- [ ] Confirm the final green commit status description reads "All tests passed across 4 shards"
- [ ] Temporarily change `shard: [1, 2, 3, 4]` to `[1, 2, 3, 4, 5]` on a throwaway branch and confirm every message switches to "5" without any other edits (revert before merge)