### PR TITLE
ci: set KANVAS_TIMEOUT_MULTIPLIER for Docker-based e2e tests

### DIFF
--- a/.github/workflows/extension-test-reusable.yml
+++ b/.github/workflows/extension-test-reusable.yml
@@ -268,6 +268,7 @@ jobs:
           REMOTE_PROVIDER_URL: https://cloud.layer5.io
           REMOTE_PROVIDER_USER_EMAIL: ${{ secrets.LAYER5_CLOUD_TESTING_BOT_EMAIL }}
           REMOTE_PROVIDER_USER_PASSWORD: ${{ secrets.LAYER5_CLOUD_TESTING_BOT_PASSWORD }}
+          KANVAS_TIMEOUT_MULTIPLIER: "3"
           ALLURE_LABEL_project: Kanvas
           ALLURE_LABEL_type: e2e
 


### PR DESCRIPTION
## Summary
- Sets `KANVAS_TIMEOUT_MULTIPLIER=3` in the e2e test workflow environment
- Fixes systemic `TimeoutError` at `KanvasPage.ts:158` where `DesignerContainer` never becomes visible within 20s in CI

## Root Cause
Commit 111f54303 calibrated all Playwright timeouts for the always-on staging environment (`staging-playground.meshery.io`), which has no cold-start penalty. CI runs against a freshly-started Docker container (`http://localhost:9081`) that needs significantly more headroom.

The `KANVAS_TIMEOUT_MULTIPLIER` mechanism in `tests/e2e/constants.ts` was designed for exactly this scenario but was not being set in CI. With a multiplier of 3, `DESIGNER_LOAD` goes from 20s to 60s.

Affects 23 of 26 tests across all 4 shards — not specific to any PR.

## Test plan
- [ ] Re-run e2e tests on an open PR and verify pass rate improves from ~12% to ~100%