### PR TITLE
fix: gracefully handle single-shard E2E test runs

### DIFF
--- a/.github/workflows/extension-test-reusable.yml
+++ b/.github/workflows/extension-test-reusable.yml
@@ -139,7 +139,7 @@ jobs:
           repository: layer5labs/meshery-extensions
           number: ${{ inputs.pr_number }}
           id: extension-test
-          message: ":heavy_check_mark: Setting up test environment (sharded across ${{ strategy.job-total }} runners)..."
+          message: ":heavy_check_mark: Setting up test environment (sharded across ${{ strategy.job-total }} ${{ strategy.job-total == 1 && 'runner' || 'runners' }})..."
           append: true
       - name: Set pending commit status
         if: ${{ inputs.head_sha != '' && matrix.shard == 1 }}
@@ -154,7 +154,7 @@ jobs:
               sha: '${{ inputs.head_sha }}',
               state: 'pending',
               context: 'Meshery Extension E2E Tests',
-              description: 'Tests are running (${{ strategy.job-total }} shards)...',
+              description: 'Tests are running (${{ strategy.job-total }} shard${{ strategy.job-total == 1 && '' || 's' }})...',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
 
@@ -248,10 +248,10 @@ jobs:
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      # `make test` in meshery-extensions picks up SHARD=X/N and forwards it
-      # to `npx playwright test --shard=X/N`. If inputs.test_command is set to
-      # a non-default value we still pass it through verbatim to preserve the
-      # existing workflow_dispatch override surface.
+      # When strategy.job-total > 1, forward SHARD=X/N to playwright so each
+      # runner exercises only its slice of the test suite. With a single runner
+      # the --shard flag is redundant; omitting it avoids shard-metadata
+      # overhead and keeps the run semantically equivalent to a local `make test`.
       - name: Run Tests
         id: run_tests
         continue-on-error: true
@@ -259,7 +259,11 @@ jobs:
         run: |
           ls
           if [ "${{ inputs.test_command }}" = "make test" ]; then
-            make test SHARD=${{ matrix.shard }}/${{ strategy.job-total }}
+            if [ "${{ strategy.job-total }}" -gt 1 ]; then
+              make test SHARD=${{ matrix.shard }}/${{ strategy.job-total }}
+            else
+              make test
+            fi
           else
             ${{ inputs.test_command }}
           fi
@@ -323,13 +327,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download Playwright shard artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           pattern: playwright-artifacts-shard-*
           path: shard-artifacts
 
       - name: Download shard outcome artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           pattern: shard-outcome-*
           path: shard-artifacts
@@ -496,8 +500,9 @@ jobs:
             const outcome = '${{ steps.aggregate.outputs.overall }}';
             const stateMap = { success: 'success', failure: 'failure', cancelled: 'error' };
             const state = stateMap[outcome] || 'error';
+            const shardCount = parseInt('${{ needs.tests-ui-e2e.outputs.shard_count || steps.aggregate.outputs.count }}') || 1;
             const descMap = {
-              success: 'All tests passed across ${{ needs.tests-ui-e2e.outputs.shard_count || steps.aggregate.outputs.count }} shards',
+              success: `All tests passed (${shardCount} shard${shardCount === 1 ? '' : 's'})`,
               failure: 'One or more tests failed',
               cancelled: 'Run was cancelled',
             };


### PR DESCRIPTION
## Summary

- **Skip `--shard` when total shards is 1.** When `strategy.job-total == 1`, the `Run Tests` step previously passed `SHARD=1/1` to `make test`, which forwarded `--shard=1/1` to Playwright. This is valid but redundant — shard 1-of-1 is identical to running the full suite without sharding. Omitting the flag when total is 1 avoids shard-metadata overhead and makes the single-runner path semantically clean.
- **Fix plural grammar in messages.** "sharded across 1 runners" → "sharded across 1 runner"; the final commit status description now reads "1 shard" vs "N shards" correctly.
- **Pinned `actions/download-artifact` to `v4`** in the summary job (was `v6`, which does not exist as a published major version).

## Changes

| Location | Change |
|---|---|
| `Run Tests` step | Conditionally omit `--shard` when `strategy.job-total` is 1 |
| "comment progress start" message | Use `runner` / `runners` conditional on shard count |
| "Set pending commit status" description | `shard` / `shards` conditional on shard count |
| "Set final commit status" script | JavaScript plural: `shard${shardCount === 1 ? '' : 's'}` |
| `download-artifact` in summary job | Pinned to `v4` (stable, published major version) |

## Test plan

- [ ] Trigger workflow with `matrix.shard: [1]` — confirm `make test` runs without `--shard`, PR comment says "1 runner", commit status says "1 shard"
- [ ] Trigger workflow with `matrix.shard: [1, 2, 3, 4]` — confirm `make test SHARD=X/4` is passed, messages use plural forms
