### PR TITLE
ci: publish extension and cloud test results to qa for PR runs

### DIFF
--- a/.github/workflows/extension-test-reusable.yml
+++ b/.github/workflows/extension-test-reusable.yml
@@ -426,11 +426,11 @@ jobs:
 
             ${{ steps.test_reports.outputs.result }}
 
-            **[Full report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})** | **[Download Playwright traces & screenshots](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**
+            **[QA dashboard for this PR](https://qa.meshery.io/pr/${{ inputs.pr_number }}/)** | **[Full report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})** | **[Download Playwright traces & screenshots](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)**
           append: true
 
       - name: Checkout QA
-        if: ${{ !cancelled() && inputs.pr_number == '' }}
+        if: ${{ !cancelled() }}
         uses: actions/checkout@v6
         with:
           repository: meshery-extensions/qa
@@ -438,7 +438,7 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Merge Allure results across shards
-        if: ${{ !cancelled() && inputs.pr_number == '' }}
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p merged-allure-results
           # Each shard may download with the original uploaded path preserved.
@@ -451,23 +451,36 @@ jobs:
             cp -R "$dir/." merged-allure-results/
           done
 
+      # Master runs populate the canonical kanvas-results/ tree that feeds the
+      # main qa.meshery.io dashboard. PR runs land under pr-reports/<N>/ so
+      # they stay isolated from the master report — qa's publish workflow's
+      # `kanvas-results/**` path filter won't fire on pr-reports/**.
       - name: Sync results with qa
-        if: ${{ !cancelled() && inputs.pr_number == '' }}
-        working-directory: qa
+        if: ${{ !cancelled() }}
         run: |
-          ls ..
-          echo "ls merged-allure-results"
-          ls ../merged-allure-results || true
-          make results-kanvas-sync KANVAS_RESULTS_PATH=../merged-allure-results
+          set -euo pipefail
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            DEST="qa/pr-reports/${{ inputs.pr_number }}/kanvas-results"
+          else
+            DEST="qa/kanvas-results"
+          fi
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+          if [ -d merged-allure-results ] && [ -n "$(ls -A merged-allure-results 2>/dev/null)" ]; then
+            cp -R merged-allure-results/. "$DEST/"
+            echo "Synced $(find "$DEST" -type f | wc -l) file(s) to $DEST"
+          else
+            echo "No merged-allure-results to sync"
+          fi
 
       - name: Commit & push results to qa
-        if: ${{ !cancelled() && inputs.pr_number == '' }}
+        if: ${{ !cancelled() }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "[Kanvas] Sync E2E Test Results - ${GITHUB_SHA}"
           commit_options: --signoff
           repository: qa
-          file_pattern: kanvas-results
+          file_pattern: ${{ inputs.pr_number != '' && format('pr-reports/{0}', inputs.pr_number) || 'kanvas-results' }}
           commit_user_name: meshery-ci
           commit_user_email: ci@meshery.io
         env:

--- a/.github/workflows/meshery-cloud-build-reusable.yml
+++ b/.github/workflows/meshery-cloud-build-reusable.yml
@@ -99,33 +99,36 @@ jobs:
         with:
           message: ":x: Failed to checkout Cloud repo."
 
-      # - name: Setup Go
-      #   uses: actions/setup-go@v6
-      #   with:
-      #     go-version-file: ./meshery-cloud/go.mod
-      #     cache: true
-      # - name: Run Go tests with coverage
-      #   id: go-test
-      #   working-directory: meshery-cloud
-      #   continue-on-error: true
-      #   run: |
-      #     set -eo pipefail
-      #     go test ./... -coverprofile=coverage.out
-      #     total=$(go tool cover -func=coverage.out | awk '/^total:/ {print $3}')
-      #     echo "total=$total" >> "$GITHUB_OUTPUT"
-      # - name: comment coverage success
-      #   if: steps.go-test.outcome == 'success'
-      #   uses: ./.github/actions/cloud-comment
-      #   with:
-      #     message: ":bar_chart: Go test coverage (go tool cover): **${{ steps.go-test.outputs.total }}**"
-      # - name: comment coverage failure
-      #   if: steps.go-test.outcome == 'failure'
-      #   uses: ./.github/actions/cloud-comment
-      #   with:
-      #     message: ":x: Go tests failed. Coverage report unavailable."
-      # - name: Fail on Go test failure
-      #   if: steps.go-test.outcome == 'failure'
-      #   run: exit 1
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: ./meshery-cloud/go.mod
+          cache: true
+      # ALLURE_OUTPUT_PATH routes allure-go writers to <path>/allure-results,
+      # which the sync-to-qa step at the end of this job picks up. We don't
+      # gate later steps on Go test pass/fail — sync runs unconditionally so
+      # the QA dashboard reflects every run.
+      - name: Run Go tests with coverage
+        id: go-test
+        working-directory: meshery-cloud
+        continue-on-error: true
+        env:
+          ALLURE_OUTPUT_PATH: ${{ github.workspace }}/meshery-cloud
+        run: |
+          set -eo pipefail
+          go test ./server/... -coverprofile=coverage.out
+          total=$(go tool cover -func=coverage.out | awk '/^total:/ {print $3}')
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+      - name: comment coverage success
+        if: steps.go-test.outcome == 'success'
+        uses: ./.github/actions/cloud-comment
+        with:
+          message: ":bar_chart: Go test coverage (go tool cover): **${{ steps.go-test.outputs.total }}**"
+      - name: comment coverage failure
+        if: steps.go-test.outcome == 'failure'
+        uses: ./.github/actions/cloud-comment
+        with:
+          message: ":x: Go tests failed. Coverage report unavailable."
 
       - name: Setup Node.js
         id: setup-node
@@ -219,6 +222,30 @@ jobs:
         uses: ./.github/actions/cloud-comment
         with:
           message: ":x: Cloud UI tests failed. Aborting staging build."
+
+      - name: Install Playwright browsers
+        working-directory: meshery-cloud/ui
+        run: npx playwright install --with-deps
+      # ALLURE_RESULTS_DIR routes allure-playwright (when wired in
+      # meshery-cloud) to a path the sync-to-qa step collects. Until that
+      # reporter is added, the directory stays empty and sync no-ops.
+      - name: Run Cloud UI e2e tests
+        id: cloud-ui-e2e
+        working-directory: meshery-cloud/ui
+        continue-on-error: true
+        env:
+          ALLURE_RESULTS_DIR: ${{ github.workspace }}/meshery-cloud/ui/allure-results
+        run: npm run e2e
+      - name: comment e2e success
+        if: steps.cloud-ui-e2e.outcome == 'success'
+        uses: ./.github/actions/cloud-comment
+        with:
+          message: ":heavy_check_mark: Cloud UI e2e tests passed."
+      - name: comment e2e failure
+        if: steps.cloud-ui-e2e.outcome == 'failure'
+        uses: ./.github/actions/cloud-comment
+        with:
+          message: ":x: Cloud UI e2e tests failed."
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4
@@ -350,6 +377,71 @@ jobs:
           message: |
             :x: Failed to deploy staging on OCI OKE
             See [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+      # Publish Cloud test results to the QA repo. Go server tests
+      # (allure-go) → meshery-server-results/. Cloud UI Jest + Playwright
+      # e2e (via allure reporters in meshery-cloud) → remote-provider-results/,
+      # the bucket aligned to the Layer5Cloud project in qa's allurerc.mjs.
+      # PR runs are routed under pr-reports/<N>/ to keep them out of the
+      # canonical master dashboard.
+      - name: Checkout QA
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@v6
+        with:
+          repository: meshery-extensions/qa
+          path: qa
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Sync Cloud test results to qa
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            BASE="qa/pr-reports/${{ inputs.pr_number }}"
+          else
+            BASE="qa"
+          fi
+          SERVER_DEST="$BASE/meshery-server-results"
+          CLOUD_DEST="$BASE/remote-provider-results"
+          rm -rf "$SERVER_DEST" "$CLOUD_DEST"
+          mkdir -p "$SERVER_DEST" "$CLOUD_DEST"
+
+          # allure-go writes into both $ALLURE_OUTPUT_PATH/allure-results
+          # and per-package allure-results dirs depending on test setup.
+          for dir in \
+            meshery-cloud/allure-results \
+            meshery-cloud/server/*/allure-results; do
+            [ -d "$dir" ] || continue
+            cp -R "$dir/." "$SERVER_DEST/" 2>/dev/null || true
+          done
+
+          for dir in meshery-cloud/ui/allure-results; do
+            [ -d "$dir" ] || continue
+            cp -R "$dir/." "$CLOUD_DEST/" 2>/dev/null || true
+          done
+
+          echo "meshery-server-results: $(find "$SERVER_DEST" -type f | wc -l) file(s)"
+          echo "remote-provider-results: $(find "$CLOUD_DEST" -type f | wc -l) file(s)"
+
+      - name: Commit & push Cloud results to qa
+        if: ${{ !cancelled() }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "[Cloud] Sync test results - ${GITHUB_SHA}"
+          commit_options: --signoff
+          repository: qa
+          file_pattern: ${{ inputs.pr_number != '' && format('pr-reports/{0}', inputs.pr_number) || 'meshery-server-results remote-provider-results' }}
+          commit_user_name: meshery-ci
+          commit_user_email: ci@meshery.io
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Comment QA dashboard link
+        if: ${{ !cancelled() && inputs.pr_number != '' }}
+        uses: ./.github/actions/cloud-comment
+        with:
+          message: ":bar_chart: [QA dashboard for this PR](https://qa.meshery.io/pr/${{ inputs.pr_number }}/)"
+
   set-final-status:
     runs-on: ubuntu-24.04
     if: always()

--- a/.github/workflows/meshery-cloud-build-reusable.yml
+++ b/.github/workflows/meshery-cloud-build-reusable.yml
@@ -223,6 +223,11 @@ jobs:
         with:
           message: ":x: Cloud UI tests failed. Aborting staging build."
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('meshery-cloud/ui/package-lock.json') }}
       - name: Install Playwright browsers
         working-directory: meshery-cloud/ui
         run: npx playwright install --with-deps


### PR DESCRIPTION
## Summary

- **Extension tests** (`extension-test-reusable.yml`): the `tests-ui-e2e-summary` job now syncs to the `qa` repo for both master and PR runs. Master continues to publish to `kanvas-results/`; PR runs land in `pr-reports/<N>/kanvas-results/`, isolated from the master dashboard so qa's `kanvas-results/**` path filter does not merge them. The summary PR comment now leads with a link to `https://qa.meshery.io/pr/<N>/`.
- **Cloud build** (`meshery-cloud-build-reusable.yml`): re-enables Go server tests with `ALLURE_OUTPUT_PATH` so allure-go output is captured; adds a Playwright e2e step (`npm run e2e` with `ALLURE_RESULTS_DIR`); and adds trailing sync-to-qa steps that route Go results to `meshery-server-results/` and Cloud UI results to `remote-provider-results/` (PR-isolated under `pr-reports/<N>/`), plus a PR comment linking to the QA dashboard.

## Follow-ups required outside this repo

For the wired data path to actually surface results on `qa.meshery.io`:

- **`meshery-cloud`**: add `allure-jest` reporter to `ui/jest.config.ts` and `allure-playwright` reporter to `ui/playwright.config.ts` (plus deps in `ui/package.json`). Until then, the Cloud UI sync step is a no-op.
- **`qa`**: extend `publish-allure-report.yml` to detect `pr-reports/*/` and publish per-PR sub-sites at `qa.meshery.io/pr/<N>/`, plus a cleanup workflow on PR close. Until then, the per-PR comment links 404.

## Test plan

- [ ] Trigger `extension-test-reusable.yml` against a PR; confirm `pr-reports/<N>/kanvas-results/` appears in the `qa` repo and the summary comment links to `qa.meshery.io/pr/<N>/`.
- [ ] Trigger `extension-test-reusable.yml` against master; confirm `kanvas-results/` continues to update normally.
- [ ] Trigger `meshery-cloud-build-reusable.yml` against a PR; confirm Go and Cloud UI results land under `pr-reports/<N>/meshery-server-results/` and `pr-reports/<N>/remote-provider-results/` respectively, and the PR comment includes the QA dashboard link.
- [ ] Trigger `meshery-cloud-build-reusable.yml` against master; confirm `meshery-server-results/` and `remote-provider-results/` update at the qa repo root.