### PR TITLE
ci(kanvas): align plugin deps with Meshery host to fix plugin.Open ABI mismatch

### DIFF
--- a/.github/workflows/build-and-release-kanvas.yml
+++ b/.github/workflows/build-and-release-kanvas.yml
@@ -89,7 +89,53 @@ jobs:
           fi
           # reset the reason otherwise
           echo "reason=" >> $GITHUB_ENV;
-          
+
+      - name: Align plugin dependencies with Meshery host versions
+        working-directory: ./meshery-extensions
+        run: |
+          # Go plugins require the plugin and host to be linked against the
+          # EXACT same version of every shared package (runtime plugin.Open
+          # otherwise fails with "plugin was built with a different version of
+          # package ..."). The `graphql-sync-err` target above only validates
+          # the generated GraphQL schema; it does NOT enforce matching go.mod
+          # versions. Here we pin every module shared with the meshery host to
+          # the exact version meshery selects, so the plugin ABI matches.
+          set -euo pipefail
+
+          # Resolve meshery's module graph (authoritative) into a lookup table.
+          (cd ../meshery && go list -m -f '{{if not .Main}}{{.Path}} {{.Version}}{{end}}' all) \
+            | awk 'NF==2' > /tmp/meshery-versions.txt
+
+          # For every module the extension uses, if meshery also uses it, pin
+          # the extension to meshery's exact version via a replace directive.
+          # Replace (not just require) forces resolution for transitive deps too.
+          go list -m -f '{{if not .Main}}{{.Path}}{{end}}' all | awk 'NF' \
+            | while read -r mod; do
+                ver=$(awk -v m="$mod" '$1==m {print $2; exit}' /tmp/meshery-versions.txt)
+                if [ -n "$ver" ]; then
+                  go mod edit -replace="${mod}=${mod}@${ver}"
+                fi
+              done
+
+          go mod tidy -e
+
+          echo "--- key shared package versions after alignment ---"
+          for pkg in \
+            github.com/vektah/gqlparser/v2 \
+            github.com/99designs/gqlgen \
+            github.com/meshery/schemas \
+            github.com/layer5io/meshkit \
+            k8s.io/client-go \
+            k8s.io/apimachinery; do
+            host_ver=$(cd ../meshery && go list -m -f '{{.Version}}' "$pkg" 2>/dev/null || echo "n/a")
+            plug_ver=$(go list -m -f '{{.Version}}' "$pkg" 2>/dev/null || echo "n/a")
+            printf '  %-45s host=%s plugin=%s\n' "$pkg" "$host_ver" "$plug_ver"
+            if [ "$host_ver" != "n/a" ] && [ "$host_ver" != "$plug_ver" ]; then
+              echo "reason=plugin/host version mismatch for $pkg (host=$host_ver plugin=$plug_ver)" >> $GITHUB_ENV
+              exit 1
+            fi
+          done
+
       - name: Setup Node 20
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- The Kanvas release workflow produces a `plugin.so` whose shared-package versions drift from the meshery host, causing runtime failures like `plugin was built with a different version of package github.com/vektah/gqlparser/v2/ast` when `plugin.Open` runs.
- The existing `make graphql-sync-err` check only validates **generated GraphQL output**; it does not enforce matching `go.mod` versions, so transitive deps (gqlparser, gqlgen, meshkit, k8s.io/*, schemas) were free to diverge.
- This PR adds an alignment step that uses meshery's resolved module graph as the source of truth and pins every shared module in the extension's `go.mod` to meshery's exact version via `replace` directives, then verifies a list of ABI-sensitive packages match before building.

## Changes
- `.github/workflows/build-and-release-kanvas.yml`: new step **"Align plugin dependencies with Meshery host versions"** between `Verify go.mod compatibility` and `Build extension`. On mismatch, the step exits non-zero and sets `reason=` so the existing failure email surfaces the cause.

## Test plan
- [ ] Trigger `Build and Release Kanvas` via `workflow_dispatch` against a known-good `MESHERY_VERSION` and confirm the alignment step passes and the published `provider-meshery.tar.gz` loads successfully with `plugin.Open` on a fresh Meshery deployment.
- [ ] Artificially bump `github.com/vektah/gqlparser/v2` in `meshery-extensions` ahead of meshery's version and re-run; confirm the step fails with `reason=plugin/host version mismatch for github.com/vektah/gqlparser/v2 ...` and the failure email reflects that reason.
- [ ] Confirm `make prod` still succeeds after `go mod tidy -e` rewrites go.mod (no missing/extra requires, no build errors).