### PR TITLE
ci: default cloud builds to Node 20.x, drop NODE_VERSION secret

### DIFF
--- a/.github/workflows/meshery-cloud-build-reusable.yml
+++ b/.github/workflows/meshery-cloud-build-reusable.yml
@@ -8,12 +8,15 @@ on:
       pr_number:
         required: true
         type: string
+      node_version:
+        description: "Node.js version for UI build/tests"
+        required: false
+        default: '20.x'
+        type: string
     secrets:
       PROVIDER_TOKEN:
         required: true
       GLOBAL_TOKEN:
-        required: true
-      NODE_VERSION:
         required: true
       GH_ACCESS_TOKEN:
         required: true
@@ -134,7 +137,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ secrets.NODE_VERSION }}
+          node-version: ${{ inputs.node_version }}
           cache: 'npm'
           cache-dependency-path: meshery-cloud/ui/package-lock.json
       - name: comment success
@@ -181,7 +184,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ secrets.NODE_VERSION }}
+          node-version: ${{ inputs.node_version }}
           cache: 'npm'
           cache-dependency-path: meshery-cloud/ui/package-lock.json
       - name: comment success

--- a/.github/workflows/meshery-cloud-on-pr.yml
+++ b/.github/workflows/meshery-cloud-on-pr.yml
@@ -12,13 +12,12 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/meshery-cloud-build-reusable.yml
-    secrets: 
-      PROVIDER_TOKEN: ${{secrets.PROVIDER_TOKEN}}      
+    secrets:
+      PROVIDER_TOKEN: ${{secrets.PROVIDER_TOKEN}}
       LAYER5_CLOUD_USERNAME: ${{secrets.LAYER5_CLOUD_USERNAME}}
       LAYER5_CLOUD_PASSWORD: ${{secrets.LAYER5_CLOUD_PASSWORD}}
       LAYER5_CLOUD_TESTING_BOT_EMAIL: ${{secrets.LAYER5_CLOUD_TESTING_BOT_EMAIL}}
       LAYER5_CLOUD_TESTING_BOT_PASSWORD: ${{secrets.LAYER5_CLOUD_TESTING_BOT_PASSWORD}}
-      NODE_VERSION: ${{secrets.NODE_VERSION}}
       GH_ACCESS_TOKEN: ${{secrets.GH_ACCESS_TOKEN}}
       DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
       DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
@@ -28,10 +27,11 @@ jobs:
       OCI_BASTION_USERNAME: ${{ secrets.OCI_BASTION_USERNAME }}
       OCI_BASTION_KEY: ${{ secrets.OCI_BASTION_KEY }}
       GLOBAL_TOKEN: ${{ secrets.GLOBAL_TOKEN }}
-      
+
     with:
       pr_commit_sha: ${{inputs.pr_commit_sha}}
       pr_number: ${{inputs.pr_number}}
+      node_version: ${{vars.NODE_VERSION || '20.x'}}
 
   test:
     uses: ./.github/workflows/meshery-cloud-test-reusable.yml
@@ -40,4 +40,4 @@ jobs:
     with:
       pr_commit_sha: ${{inputs.pr_commit_sha}}
       pr_number: ${{inputs.pr_number}}
-      node_version: ${{vars.NODE_VERSION}}
+      node_version: ${{vars.NODE_VERSION || '20.x'}}

--- a/.github/workflows/meshery-cloud-on-pr.yml
+++ b/.github/workflows/meshery-cloud-on-pr.yml
@@ -8,6 +8,10 @@ on:
       pr_number:
         required: true
         type: string
+      node_version:
+        description: "Node.js version for UI build/tests (overrides vars.NODE_VERSION for this run)"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -31,7 +35,7 @@ jobs:
     with:
       pr_commit_sha: ${{inputs.pr_commit_sha}}
       pr_number: ${{inputs.pr_number}}
-      node_version: ${{vars.NODE_VERSION || '20.x'}}
+      node_version: ${{inputs.node_version || vars.NODE_VERSION || '20.x'}}
 
   test:
     uses: ./.github/workflows/meshery-cloud-test-reusable.yml
@@ -40,4 +44,4 @@ jobs:
     with:
       pr_commit_sha: ${{inputs.pr_commit_sha}}
       pr_number: ${{inputs.pr_number}}
-      node_version: ${{vars.NODE_VERSION || '20.x'}}
+      node_version: ${{inputs.node_version || vars.NODE_VERSION || '20.x'}}

--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -19,7 +19,8 @@ on:
         type: boolean
       node_version:
         description: "Node.js version for UI tests"
-        required: true
+        required: false
+        default: '20.x'
         type: string
     secrets:
       GH_ACCESS_TOKEN:
@@ -42,7 +43,8 @@ on:
         type: boolean
       node_version:
         description: "Node.js version for UI tests"
-        required: true
+        required: false
+        default: '20.x'
         type: string
 
 jobs:


### PR DESCRIPTION
## Summary

- The \`meshery-cloud-build-reusable\` workflow was setting up Node from \`secrets.NODE_VERSION\`, which currently resolves to **Node 18.20.8** on the runner. The Meshery-Cloud UI now uses ES2023 \`Array.prototype.toSorted\`, so the Playwright-spawned Next.js dev server dies with:

  \`\`\`
  [WebServer] Unhandled Rejection: TypeError: features.toSorted is not a function
  \`\`\`

  This has been failing every PR in [layer5io/meshery-cloud](https://github.com/layer5io/meshery-cloud) — most recently [PR #5048](https://github.com/layer5io/meshery-cloud/pull/5048) and [PR #5047](https://github.com/layer5io/meshery-cloud/pull/5047).

- Switch the reusable build workflow to an \`inputs.node_version\` parameter (matching the shape of \`meshery-cloud-test-reusable\`) and default both reusables to \`'20.x'\`. The on-PR dispatcher now passes \`\${{ vars.NODE_VERSION || '20.x' }}\` so operators can still override via a repo/org **variable** without the value living in a secret.

- \`NODE_VERSION\` is no longer a required secret on the build reusable; the declaration in \`meshery-cloud-build-reusable.yml\` is removed and the passthrough in \`meshery-cloud-on-pr.yml\` is dropped. Other workflows (\`extension-test-reusable\`, \`build-and-release-kanvas\`, etc.) are untouched — they already pin Node locally.

## Files touched

- \`.github/workflows/meshery-cloud-build-reusable.yml\` — add \`node_version\` input (default \`'20.x'\`); remove \`NODE_VERSION\` from required secrets; wire \`setup-node\` to \`inputs.node_version\` in both places.
- \`.github/workflows/meshery-cloud-on-pr.yml\` — drop the \`NODE_VERSION\` secret passthrough; forward \`vars.NODE_VERSION || '20.x'\` to both the build and test reusables.
- \`.github/workflows/meshery-cloud-test-reusable.yml\` — make \`node_version\` optional with a default of \`'20.x'\` so ad-hoc dispatch doesn't need the param.

## Test plan

- [ ] Merge this PR, then re-run the Meshery Cloud Build on a pending meshery-cloud PR (e.g. [layer5io/meshery-cloud#5048](https://github.com/layer5io/meshery-cloud/pull/5048)) and confirm Node reports **20.x** in the \`Setup Node.js\` step.
- [ ] Confirm \`Run Cloud UI e2e tests\` no longer throws \`features.toSorted is not a function\`.
- [ ] (Optional) Set repo variable \`NODE_VERSION\` to a pinned value (e.g. \`22.x\`) and confirm the dispatcher forwards it.