### PR TITLE
ci: dedupe cloud build workflow and always publish QA results

### DIFF
--- a/.github/workflows/meshery-cloud-build-reusable.yml
+++ b/.github/workflows/meshery-cloud-build-reusable.yml
@@ -64,6 +64,7 @@ jobs:
   build-meshery-cloud:
     name: Server Build
     runs-on: ubuntu-24.04
+    timeout-minutes: 25
     env:
       GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       PR_NUMBER: ${{ inputs.pr_number }}
@@ -102,37 +103,8 @@ jobs:
         with:
           message: ":x: Failed to checkout Cloud repo."
 
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: ./meshery-cloud/go.mod
-          cache: true
-      # ALLURE_OUTPUT_PATH routes allure-go writers to <path>/allure-results,
-      # which the sync-to-qa step at the end of this job picks up. We don't
-      # gate later steps on Go test pass/fail — sync runs unconditionally so
-      # the QA dashboard reflects every run.
-      - name: Run Go tests with coverage
-        id: go-test
-        working-directory: meshery-cloud
-        continue-on-error: true
-        env:
-          ALLURE_OUTPUT_PATH: ${{ github.workspace }}/meshery-cloud
-        run: |
-          set -eo pipefail
-          go test ./server/... -coverprofile=coverage.out
-          total=$(go tool cover -func=coverage.out | awk '/^total:/ {print $3}')
-          echo "total=$total" >> "$GITHUB_OUTPUT"
-      - name: comment coverage success
-        if: steps.go-test.outcome == 'success'
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":bar_chart: Go test coverage (go tool cover): **${{ steps.go-test.outputs.total }}**"
-      - name: comment coverage failure
-        if: steps.go-test.outcome == 'failure'
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":x: Go tests failed. Coverage report unavailable."
-
+      # Unit, integration, and Jest UI tests run in meshery-cloud-test-reusable.yml.
+      # This workflow owns Playwright e2e + image build + deploy only.
       - name: Setup Node.js
         id: setup-node
         uses: actions/setup-node@v6
@@ -144,12 +116,12 @@ jobs:
         if: steps.setup-node.outcome == 'success'
         uses: ./.github/actions/cloud-comment
         with:
-          message: ":heavy_check_mark: Setup Node.js for Cloud UI validation. Installing dependencies..."
+          message: ":heavy_check_mark: Setup Node.js for Playwright e2e. Installing dependencies..."
       - name: comment failure
         if: steps.setup-node.outcome == 'failure'
         uses: ./.github/actions/cloud-comment
         with:
-          message: ":x: Failed to setup Node.js for Cloud UI validation."
+          message: ":x: Failed to setup Node.js for Playwright e2e."
 
       - name: Install Cloud UI dependencies
         id: install-cloud-ui-deps
@@ -159,72 +131,12 @@ jobs:
         if: steps.install-cloud-ui-deps.outcome == 'success'
         uses: ./.github/actions/cloud-comment
         with:
-          message: ":heavy_check_mark: Installed Cloud UI dependencies. Running Cloud UI tests..."
+          message: ":heavy_check_mark: Installed Cloud UI dependencies."
       - name: comment failure
         if: steps.install-cloud-ui-deps.outcome == 'failure'
         uses: ./.github/actions/cloud-comment
         with:
           message: ":x: Failed to install Cloud UI dependencies."
-
-      - name: Run Cloud UI tests
-        id: cloud-ui-tests
-        working-directory: meshery-cloud
-        run: make cloud-ui-tests
-      - name: comment success
-        if: steps.cloud-ui-tests.outcome == 'success'
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":heavy_check_mark: Cloud UI tests passed. Proceeding with staging build setup."
-      - name: comment failure
-        if: failure()
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":x: Cloud UI tests failed. Aborting staging build."
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ inputs.node_version }}
-          cache: 'npm'
-          cache-dependency-path: meshery-cloud/ui/package-lock.json
-      - name: comment success
-        if: success()
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":heavy_check_mark: Setup Node.js for Cloud UI validation. Installing dependencies..."
-      - name: comment failure
-        if: failure()
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":x: Failed to setup Node.js for Cloud UI validation."
-
-      - name: Install Cloud UI dependencies
-        working-directory: meshery-cloud
-        run: make ui-setup
-      - name: comment success
-        if: success()
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":heavy_check_mark: Installed Cloud UI dependencies. Running Cloud UI tests..."
-      - name: comment failure
-        if: failure()
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":x: Failed to install Cloud UI dependencies."
-
-      - name: Run Cloud UI tests
-        working-directory: meshery-cloud
-        run: make cloud-ui-tests
-      - name: comment success
-        if: success()
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":heavy_check_mark: Cloud UI tests passed. Proceeding with staging build setup."
-      - name: comment failure
-        if: failure()
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":x: Cloud UI tests failed. Aborting staging build."
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -386,12 +298,12 @@ jobs:
             :x: Failed to deploy staging on OCI OKE
             See [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
-      # Publish Cloud test results to the QA repo. Go server tests
-      # (allure-go) → meshery-server-results/. Cloud UI Jest + Playwright
-      # e2e (via allure reporters in meshery-cloud) → remote-provider-results/,
+      # Publish Playwright e2e results to the QA repo. Unit/integration/Jest
+      # results are synced by meshery-cloud-test-reusable.yml. Playwright
+      # (allure-playwright in meshery-cloud) → remote-provider-results/,
       # the bucket aligned to the Layer5Cloud project in qa's allurerc.mjs.
-      # PR runs are routed under pr-reports/<N>/ to keep them out of the
-      # canonical master dashboard.
+      # PR runs route under pr-reports/<N>/ so they stay out of master's
+      # dashboard. Runs on !cancelled() so failing results still land.
       - name: Checkout QA
         if: ${{ !cancelled() }}
         uses: actions/checkout@v6
@@ -400,7 +312,7 @@ jobs:
           path: qa
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
-      - name: Sync Cloud test results to qa
+      - name: Sync Cloud e2e results to qa
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
@@ -409,36 +321,25 @@ jobs:
           else
             BASE="qa"
           fi
-          SERVER_DEST="$BASE/meshery-server-results"
           CLOUD_DEST="$BASE/remote-provider-results"
-          rm -rf "$SERVER_DEST" "$CLOUD_DEST"
-          mkdir -p "$SERVER_DEST" "$CLOUD_DEST"
-
-          # allure-go writes into both $ALLURE_OUTPUT_PATH/allure-results
-          # and per-package allure-results dirs depending on test setup.
-          for dir in \
-            meshery-cloud/allure-results \
-            meshery-cloud/server/*/allure-results; do
-            [ -d "$dir" ] || continue
-            cp -R "$dir/." "$SERVER_DEST/" 2>/dev/null || true
-          done
+          rm -rf "$CLOUD_DEST"
+          mkdir -p "$CLOUD_DEST"
 
           for dir in meshery-cloud/ui/allure-results; do
             [ -d "$dir" ] || continue
             cp -R "$dir/." "$CLOUD_DEST/" 2>/dev/null || true
           done
 
-          echo "meshery-server-results: $(find "$SERVER_DEST" -type f | wc -l) file(s)"
           echo "remote-provider-results: $(find "$CLOUD_DEST" -type f | wc -l) file(s)"
 
-      - name: Commit & push Cloud results to qa
+      - name: Commit & push Cloud e2e results to qa
         if: ${{ !cancelled() }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "[Cloud] Sync test results - ${GITHUB_SHA}"
+          commit_message: "[Cloud] Sync e2e results - ${GITHUB_SHA}"
           commit_options: --signoff
           repository: qa
-          file_pattern: ${{ inputs.pr_number != '' && format('pr-reports/{0}', inputs.pr_number) || 'meshery-server-results remote-provider-results' }}
+          file_pattern: ${{ inputs.pr_number != '' && format('pr-reports/{0}', inputs.pr_number) || 'remote-provider-results' }}
           commit_user_name: meshery-ci
           commit_user_email: ci@meshery.io
         env:

--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -185,50 +185,63 @@ jobs:
       #------------------------------------------
 
       #------------------------------------------
-      - name: Checkout qa.meshery.io repo
-        if: ${{ inputs.pr_number == '' && steps.unit-tests.outcome == 'success' && (steps.integration-tests.outcome == 'success' || steps.integration-tests.outcome == 'skipped') }}
+      # Publish server test results (pass or fail) to qa.meshery.io. PR runs
+      # route under pr-reports/<N>/ so they stay out of the master dashboard.
+      # The sync is intentionally ungated on test outcome — failing runs must
+      # land so the dashboard reflects every CI run.
+      - name: Checkout QA
+        if: ${{ !cancelled() }}
         uses: actions/checkout@v6
         with:
-          repository: meshery/qa
+          repository: meshery-extensions/qa
           path: qa
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
-      - name: Sync results with QA
-        if: ${{ inputs.pr_number == '' && steps.unit-tests.outcome == 'success' && (steps.integration-tests.outcome == 'success' || steps.integration-tests.outcome == 'skipped') }}
-        working-directory: qa
-        run: make remote-provider-results-sync REMOTE_PROVIDER_RESULTS_PATH=../meshery-cloud/allure-results/
+      - name: Sync server test results to qa
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            BASE="qa/pr-reports/${{ inputs.pr_number }}"
+          else
+            BASE="qa"
+          fi
+          SERVER_DEST="$BASE/meshery-server-results"
+          rm -rf "$SERVER_DEST"
+          mkdir -p "$SERVER_DEST"
+          for dir in \
+            meshery-cloud/allure-results \
+            meshery-cloud/server/*/allure-results; do
+            [ -d "$dir" ] || continue
+            cp -R "$dir/." "$SERVER_DEST/" 2>/dev/null || true
+          done
+          echo "meshery-server-results: $(find "$SERVER_DEST" -type f | wc -l) file(s)"
 
-      - name: Commit & push results to QA
-        if: ${{ inputs.pr_number == '' && steps.unit-tests.outcome == 'success' && (steps.integration-tests.outcome == 'success' || steps.integration-tests.outcome == 'skipped') }}
+      - name: Commit & push server results to qa
+        if: ${{ !cancelled() }}
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: "[Extension] Sync Remote Provider Cloud Server Test Results - ${{ github.sha }}"
+          commit_message: "[Cloud] Sync server test results - ${GITHUB_SHA}"
           commit_options: --signoff
           repository: qa
-          file_pattern: "remote-provider-results/**"
+          file_pattern: ${{ inputs.pr_number != '' && format('pr-reports/{0}', inputs.pr_number) || 'meshery-server-results' }}
           commit_user_name: meshery-ci
           commit_user_email: ci@meshery.io
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Comment QA sync success
-        if: ${{ success() && inputs.pr_number == '' && steps.unit-tests.outcome == 'success' && (steps.integration-tests.outcome == 'success' || steps.integration-tests.outcome == 'skipped') }}
+        if: ${{ success() && !cancelled() }}
         uses: ./.github/actions/cloud-comment
         with:
           id: cloud-tests
-          message: ":heavy_check_mark: Sync'ed test results to qa.meshery.io repo."
+          message: ":heavy_check_mark: Synced server test results to QA dashboard."
       - name: Comment QA sync failure
-        if: ${{ failure() && inputs.pr_number == '' && steps.unit-tests.outcome == 'success' && (steps.integration-tests.outcome == 'success' || steps.integration-tests.outcome == 'skipped') }}
+        if: ${{ failure() }}
         uses: ./.github/actions/cloud-comment
         with:
           id: cloud-tests
-          message: ":x: Failed to sync test results to qa.meshery.io repo."
-      - name: Comment QA sync skipped
-        if: ${{ inputs.pr_number == '' && (steps.unit-tests.outcome == 'failure' || steps.integration-tests.outcome == 'failure') }}
-        uses: ./.github/actions/cloud-comment
-        with:
-          id: cloud-tests
-          message: ":warning: Skipped QA sync — test failures detected."
+          message: ":x: Failed to sync server test results to QA dashboard."
       #------------------------------------------
 
       #------------------------------------------
@@ -372,4 +385,47 @@ jobs:
         with:
           id: cloud-ui-tests
           message: ":x: Cloud UI tests failed. See [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+      #------------------------------------------
+
+      #------------------------------------------
+      # Publish UI (Jest) results to qa.meshery.io. Runs on pass or fail.
+      # Until meshery-cloud wires an allure-jest reporter into the ui target,
+      # meshery-cloud/ui/allure-results will be empty and this step no-ops.
+      - name: Checkout QA
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@v6
+        with:
+          repository: meshery-extensions/qa
+          path: qa
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Sync UI test results to qa
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            BASE="qa/pr-reports/${{ inputs.pr_number }}"
+          else
+            BASE="qa"
+          fi
+          UI_DEST="$BASE/remote-provider-results"
+          mkdir -p "$UI_DEST"
+          for dir in meshery-cloud/ui/allure-results; do
+            [ -d "$dir" ] || continue
+            cp -R "$dir/." "$UI_DEST/" 2>/dev/null || true
+          done
+          echo "remote-provider-results (UI): $(find "$UI_DEST" -type f | wc -l) file(s)"
+
+      - name: Commit & push UI results to qa
+        if: ${{ !cancelled() }}
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "[Cloud] Sync UI test results - ${GITHUB_SHA}"
+          commit_options: --signoff
+          repository: qa
+          file_pattern: ${{ inputs.pr_number != '' && format('pr-reports/{0}', inputs.pr_number) || 'remote-provider-results' }}
+          commit_user_name: meshery-ci
+          commit_user_email: ci@meshery.io
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       #------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the `meshery-cloud-build-reusable.yml` timeout and makes QA publishing consistent across the two Cloud workflows.

### `meshery-cloud-build-reusable.yml`
- Removed the duplicated `Setup Node.js` / `Install Cloud UI dependencies` / `Run Cloud UI tests` block — this ran the same three steps twice in a row and was the primary source of the timeout.
- Removed `Setup Go` + `Run Go tests with coverage` and the Jest UI test step. Unit / integration / Jest tests are owned by `meshery-cloud-test-reusable.yml`; running them here too was pure duplication.
- Added `timeout-minutes: 25` so future regressions surface fast instead of hitting the 6-hour default ceiling.
- Scoped the QA sync to Playwright e2e only (`remote-provider-results/`) since server results now come from the test reusable.

### `meshery-cloud-test-reusable.yml`
- QA sync now runs on `!cancelled()` so **failing** runs publish too. Previously the sync was gated on `unit-tests.outcome == 'success'`, so red runs never reached the dashboard.
- Unified the target repo on `meshery-extensions/qa` (matches the build workflow). The test workflow was pointing at `meshery/qa`, splitting results across two repos.
- PR runs route under `pr-reports/<N>/` — same convention as the build workflow.
- Added a QA sync step to the `ui-tests` job (was previously not publishing anything). No-ops until meshery-cloud wires an allure-jest reporter; flagged in a comment.

### Follow-ups worth flagging
1. Three jobs now push to `meshery-extensions/qa` in parallel. `stefanzweifel/git-auto-commit-action` retries on non-fast-forward and each writes to a distinct subpath, so conflicts should resolve — but consolidating into a single post-job sync is the more robust long-term fix.
2. Playwright e2e still lives in the build workflow. Cleanest final state is to move it to `ui-tests` so the build workflow is pure "build + deploy." Out of scope here.
3. `make cloud-ui-tests` vs `make ui-tests` — the test workflow uses the latter, the (now-removed) build workflow block used the former. Worth confirming they are equivalent in meshery-cloud's Makefile.

## Test plan

- [ ] Trigger a PR run against meshery-cloud: confirm build workflow finishes under 25 min, no duplicate Node/UI steps appear in logs.
- [ ] Confirm failing unit test in a meshery-cloud PR still results in a commit landing in `meshery-extensions/qa` under `pr-reports/<N>/meshery-server-results/`.
- [ ] Confirm master run publishes to `meshery-extensions/qa` at the repo root (`meshery-server-results/`, `remote-provider-results/`).
- [ ] Confirm the ui-tests job's sync step runs to completion (even if currently a no-op) and does not error.