### PR TITLE
ci: move Playwright e2e to test workflow so it parallelizes with build

### DIFF
--- a/.github/workflows/meshery-cloud-build-reusable.yml
+++ b/.github/workflows/meshery-cloud-build-reusable.yml
@@ -103,70 +103,9 @@ jobs:
         with:
           message: ":x: Failed to checkout Cloud repo."
 
-      # Unit, integration, and Jest UI tests run in meshery-cloud-test-reusable.yml.
-      # This workflow owns Playwright e2e + image build + deploy only.
-      - name: Setup Node.js
-        id: setup-node
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ inputs.node_version }}
-          cache: 'npm'
-          cache-dependency-path: meshery-cloud/ui/package-lock.json
-      - name: comment success
-        if: steps.setup-node.outcome == 'success'
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":heavy_check_mark: Setup Node.js for Playwright e2e. Installing dependencies..."
-      - name: comment failure
-        if: steps.setup-node.outcome == 'failure'
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":x: Failed to setup Node.js for Playwright e2e."
-
-      - name: Install Cloud UI dependencies
-        id: install-cloud-ui-deps
-        working-directory: meshery-cloud
-        run: make ui-setup
-      - name: comment success
-        if: steps.install-cloud-ui-deps.outcome == 'success'
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":heavy_check_mark: Installed Cloud UI dependencies."
-      - name: comment failure
-        if: steps.install-cloud-ui-deps.outcome == 'failure'
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":x: Failed to install Cloud UI dependencies."
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('meshery-cloud/ui/package-lock.json') }}
-      - name: Install Playwright browsers
-        working-directory: meshery-cloud/ui
-        run: npx playwright install --with-deps
-      # ALLURE_RESULTS_DIR routes allure-playwright (when wired in
-      # meshery-cloud) to a path the sync-to-qa step collects. Until that
-      # reporter is added, the directory stays empty and sync no-ops.
-      - name: Run Cloud UI e2e tests
-        id: cloud-ui-e2e
-        working-directory: meshery-cloud/ui
-        continue-on-error: true
-        env:
-          ALLURE_RESULTS_DIR: ${{ github.workspace }}/meshery-cloud/ui/allure-results
-        run: npm run e2e
-      - name: comment e2e success
-        if: steps.cloud-ui-e2e.outcome == 'success'
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":heavy_check_mark: Cloud UI e2e tests passed."
-      - name: comment e2e failure
-        if: steps.cloud-ui-e2e.outcome == 'failure'
-        uses: ./.github/actions/cloud-comment
-        with:
-          message: ":x: Cloud UI e2e tests failed."
-
+      # All tests (unit, integration, Jest, Playwright e2e) run in
+      # meshery-cloud-test-reusable.yml so they parallelize with image
+      # build + deploy. This workflow is pure build + deploy.
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4
       - name: comment success
@@ -298,53 +237,9 @@ jobs:
             :x: Failed to deploy staging on OCI OKE
             See [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
-      # Publish Playwright e2e results to the QA repo. Unit/integration/Jest
-      # results are synced by meshery-cloud-test-reusable.yml. Playwright
-      # (allure-playwright in meshery-cloud) → remote-provider-results/,
-      # the bucket aligned to the Layer5Cloud project in qa's allurerc.mjs.
-      # PR runs route under pr-reports/<N>/ so they stay out of master's
-      # dashboard. Runs on !cancelled() so failing results still land.
-      - name: Checkout QA
-        if: ${{ !cancelled() }}
-        uses: actions/checkout@v6
-        with:
-          repository: meshery-extensions/qa
-          path: qa
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-
-      - name: Sync Cloud e2e results to qa
-        if: ${{ !cancelled() }}
-        run: |
-          set -euo pipefail
-          if [ -n "${{ inputs.pr_number }}" ]; then
-            BASE="qa/pr-reports/${{ inputs.pr_number }}"
-          else
-            BASE="qa"
-          fi
-          CLOUD_DEST="$BASE/remote-provider-results"
-          rm -rf "$CLOUD_DEST"
-          mkdir -p "$CLOUD_DEST"
-
-          for dir in meshery-cloud/ui/allure-results; do
-            [ -d "$dir" ] || continue
-            cp -R "$dir/." "$CLOUD_DEST/" 2>/dev/null || true
-          done
-
-          echo "remote-provider-results: $(find "$CLOUD_DEST" -type f | wc -l) file(s)"
-
-      - name: Commit & push Cloud e2e results to qa
-        if: ${{ !cancelled() }}
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "[Cloud] Sync e2e results - ${GITHUB_SHA}"
-          commit_options: --signoff
-          repository: qa
-          file_pattern: ${{ inputs.pr_number != '' && format('pr-reports/{0}', inputs.pr_number) || 'remote-provider-results' }}
-          commit_user_name: meshery-ci
-          commit_user_email: ci@meshery.io
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-
+      # QA dashboard is populated by meshery-cloud-test-reusable.yml. This
+      # step just surfaces the link on PR runs once the build + deploy path
+      # has finished.
       - name: Comment QA dashboard link
         if: ${{ !cancelled() && inputs.pr_number != '' }}
         uses: ./.github/actions/cloud-comment

--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -433,7 +433,7 @@ jobs:
   e2e-tests:
     name: Playwright e2e
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       PR_NUMBER: ${{ inputs.pr_number }}
@@ -487,11 +487,12 @@ jobs:
       # ALLURE_RESULTS_DIR routes allure-playwright (when wired in
       # meshery-cloud) to a path the sync-to-qa step collects. Until that
       # reporter is added, the directory stays empty and sync no-ops.
-      # Per-step timeout-minutes catches a hung test before the job-level
-      # budget, which would otherwise also kill the sync step.
+      # Step timeout is set below the job timeout so a hung test fails
+      # with room left for the QA sync + gating step to run. Current
+      # observed e2e runtime is ~22 min; 25 min gives a small buffer.
       - name: Run Cloud UI e2e tests
         id: e2e
-        timeout-minutes: 15
+        timeout-minutes: 25
         continue-on-error: true
         working-directory: meshery-cloud/ui
         env:
@@ -531,6 +532,10 @@ jobs:
           path: qa
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
+      # Clear the destination before copying so removed/renamed result
+      # files don't linger as stale entries on the QA dashboard. Safe in
+      # this job because no other parallel job writes to the same subtree
+      # within this run (the ui-tests Jest sync is currently a no-op).
       - name: Sync e2e results to qa
         if: ${{ !cancelled() }}
         run: |
@@ -541,6 +546,7 @@ jobs:
             BASE="qa"
           fi
           E2E_DEST="$BASE/remote-provider-results"
+          rm -rf "$E2E_DEST"
           mkdir -p "$E2E_DEST"
           for dir in meshery-cloud/ui/allure-results; do
             [ -d "$dir" ] || continue
@@ -560,4 +566,12 @@ jobs:
           commit_user_email: ci@meshery.io
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      # Gate after the sync so failing e2e results still publish to QA
+      # while the job correctly surfaces as failed in PR checks.
+      - name: Fail job if e2e failed
+        if: steps.e2e.outcome == 'failure'
+        run: |
+          echo "::error::Playwright e2e tests failed"
+          exit 1
       #------------------------------------------

--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -429,3 +429,135 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       #------------------------------------------
+
+  e2e-tests:
+    name: Playwright e2e
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+    steps:
+      - name: Checkout for composite action
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/actions/cloud-comment
+          sparse-checkout-cone-mode: false
+
+      - name: Comment starting
+        uses: ./.github/actions/cloud-comment
+        with:
+          id: cloud-e2e-tests
+          message: "Starting Cloud Playwright e2e ([workflow run](https://github.com/layer5labs/meshery-extensions-packages/actions/runs/${{ github.run_id }}))..."
+          append: false
+          recreate: true
+
+      - name: Checkout Cloud code
+        uses: actions/checkout@v6
+        with:
+          repository: layer5io/meshery-cloud
+          ref: ${{ inputs.pr_number != '' && format('refs/pull/{0}/head', inputs.pr_number) || inputs.pr_commit_sha }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          fetch-depth: 1
+          path: meshery-cloud
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: 'npm'
+          cache-dependency-path: meshery-cloud/ui/package-lock.json
+
+      - name: Install Cloud UI dependencies
+        working-directory: meshery-cloud
+        run: make ui-setup
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('meshery-cloud/ui/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        working-directory: meshery-cloud/ui
+        run: npx playwright install --with-deps
+
+      # ALLURE_RESULTS_DIR routes allure-playwright (when wired in
+      # meshery-cloud) to a path the sync-to-qa step collects. Until that
+      # reporter is added, the directory stays empty and sync no-ops.
+      # Per-step timeout-minutes catches a hung test before the job-level
+      # budget, which would otherwise also kill the sync step.
+      - name: Run Cloud UI e2e tests
+        id: e2e
+        timeout-minutes: 15
+        continue-on-error: true
+        working-directory: meshery-cloud/ui
+        env:
+          ALLURE_RESULTS_DIR: ${{ github.workspace }}/meshery-cloud/ui/allure-results
+        run: npm run e2e
+
+      - name: Comment e2e success
+        if: steps.e2e.outcome == 'success'
+        uses: ./.github/actions/cloud-comment
+        with:
+          id: cloud-e2e-tests
+          message: ":white_check_mark: Cloud Playwright e2e tests passed."
+      - name: Comment e2e failure
+        if: steps.e2e.outcome == 'failure'
+        uses: ./.github/actions/cloud-comment
+        with:
+          id: cloud-e2e-tests
+          message: ":x: Cloud Playwright e2e tests failed. See [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
+      - name: Upload e2e test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-results
+          path: meshery-cloud/ui/allure-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      #------------------------------------------
+      # Publish Playwright e2e results to qa.meshery.io. Runs on pass or
+      # fail. PR runs route under pr-reports/<N>/.
+      - name: Checkout QA
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@v6
+        with:
+          repository: meshery-extensions/qa
+          path: qa
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Sync e2e results to qa
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            BASE="qa/pr-reports/${{ inputs.pr_number }}"
+          else
+            BASE="qa"
+          fi
+          E2E_DEST="$BASE/remote-provider-results"
+          mkdir -p "$E2E_DEST"
+          for dir in meshery-cloud/ui/allure-results; do
+            [ -d "$dir" ] || continue
+            cp -R "$dir/." "$E2E_DEST/" 2>/dev/null || true
+          done
+          echo "remote-provider-results (e2e): $(find "$E2E_DEST" -type f | wc -l) file(s)"
+
+      - name: Commit & push e2e results to qa
+        if: ${{ !cancelled() }}
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "[Cloud] Sync e2e results - ${GITHUB_SHA}"
+          commit_options: --signoff
+          repository: qa
+          file_pattern: ${{ inputs.pr_number != '' && format('pr-reports/{0}', inputs.pr_number) || 'remote-provider-results' }}
+          commit_user_name: meshery-ci
+          commit_user_email: ci@meshery.io
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      #------------------------------------------


### PR DESCRIPTION
## Summary

The build workflow is still timing out. Root cause from run [24744903534](https://github.com/layer5labs/meshery-extensions-packages/actions/runs/24744903534): `Run Cloud UI e2e tests` has been running 22+ min while Docker build + deploy sit behind it. The 25-min job timeout from #697 will kill the whole chain before deploy even starts.

**Fix:** move Playwright e2e into a dedicated `e2e-tests` job in the test reusable so it parallelizes with image build + deploy.

Wall-clock after this change: `max(e2e, build+deploy)` instead of `e2e + build + deploy`. For the current run that's ~22 min vs. ~35+ min.

## Changes

### `meshery-cloud-test-reusable.yml`
- New `e2e-tests` job: checkout → Node → `make ui-setup` → Playwright install (with cache) → `npm run e2e` → QA sync.
- Per-step `timeout-minutes: 15` on the e2e run so a hung test fails quickly — the previous job-level-only timeout would also kill the downstream QA sync.
- E2e results publish to `remote-provider-results/` on `meshery-extensions/qa`, PR runs under `pr-reports/<N>/`.
- `continue-on-error: true` on the e2e step so the QA sync always gets a chance to publish, even on failure.

### `meshery-cloud-build-reusable.yml`
- Removed Setup Node, Install Cloud UI deps, Cache/Install Playwright, Run e2e, QA-checkout/sync/push. Those are now the test workflow's responsibility.
- Kept: checkout → Docker meta/login/build/push → deploy → QA dashboard link comment.

## Out of scope / follow-ups

1. **Investigate why e2e takes 22+ min** — this PR just moves the cost off the critical path, it does not shrink it. Worth checking meshery-cloud's `npm run e2e` for hangs vs. genuinely large suite; sharding with `--shard=1/N` across matrix runners is the next lever.
2. Build workflow timeout is still 25 min. Can likely drop to 15–20 min once we confirm Docker build + deploy is consistently <12 min.

## Test plan

- [ ] Trigger a PR run: confirm e2e and build run in parallel (two separate jobs, separate timelines).
- [ ] Confirm build workflow finishes in <15 min when e2e is out of the critical path.
- [ ] Confirm e2e results land in `meshery-extensions/qa` under `pr-reports/<N>/remote-provider-results/` on PR runs.
- [ ] Confirm e2e results land in `meshery-extensions/qa` under `remote-provider-results/` on master runs.
- [ ] Confirm the 15-min per-step timeout fires correctly if e2e hangs.