### PR TITLE
Increase timeout for Cloud UI e2e tests to 35 minutes

### DIFF
--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -492,7 +492,7 @@ jobs:
       # observed e2e runtime is ~22 min; 25 min gives a small buffer.
       - name: Run Cloud UI e2e tests
         id: e2e
-        timeout-minutes: 25
+        timeout-minutes: 35
         continue-on-error: true
         working-directory: meshery-cloud/ui
         env:


### PR DESCRIPTION
Increased timeout for Cloud UI e2e tests to allow for longer execution.

**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
