### PR TITLE
ci: surface test failure specifics in PR comments

### DIFF
--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -129,7 +129,10 @@ jobs:
         id: unit-tests
         continue-on-error: true
         working-directory: meshery-cloud
-        run: make server-tests-unit 2>&1 | tee /tmp/unit-test-output.txt
+        shell: bash
+        run: |
+          set -o pipefail
+          make server-tests-unit 2>&1 | tee /tmp/unit-test-output.txt
 
       - name: Comment unit tests success
         if: steps.unit-tests.outcome == 'success'
@@ -163,9 +166,9 @@ jobs:
             if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
               BLOCKS=$(grep -E "^--- FAIL:|^FAIL[[:space:]]|Error:|panic:|cannot " "$OUTPUT" 2>/dev/null | head -40 || true)
             fi
-            # Final fallback: last 50 lines
+            # Final fallback: safe message pointing to full logs (avoids posting raw output)
             if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
-              BLOCKS=$(tail -n 50 "$OUTPUT")
+              BLOCKS="(no specific failure patterns matched — see full logs for details)"
             fi
             BLOCKS=$(echo "$BLOCKS" | head -c 5000)
           fi
@@ -195,7 +198,10 @@ jobs:
         continue-on-error: true
         if: ${{ inputs.run_integration_tests }}
         working-directory: meshery-cloud
-        run: make ENVIRONMENT=staging server-tests-integration 2>&1 | tee /tmp/integration-test-output.txt
+        shell: bash
+        run: |
+          set -o pipefail
+          make ENVIRONMENT=staging server-tests-integration 2>&1 | tee /tmp/integration-test-output.txt
 
       - name: Comment integration tests success
         if: steps.integration-tests.outcome == 'success'
@@ -234,7 +240,7 @@ jobs:
               BLOCKS=$(grep -E "^--- FAIL:|^FAIL[[:space:]]|Error:|panic:|cannot " "$OUTPUT" 2>/dev/null | head -40 || true)
             fi
             if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
-              BLOCKS=$(tail -n 50 "$OUTPUT")
+              BLOCKS="(no specific failure patterns matched — see full logs for details)"
             fi
             BLOCKS=$(echo "$BLOCKS" | head -c 5000)
           fi
@@ -458,7 +464,10 @@ jobs:
         id: ui-tests
         continue-on-error: true
         working-directory: meshery-cloud
-        run: make ui-tests 2>&1 | tee /tmp/ui-test-output.txt
+        shell: bash
+        run: |
+          set -o pipefail
+          make ui-tests 2>&1 | tee /tmp/ui-test-output.txt
 
       - name: Upload UI test results
         if: always()
@@ -503,7 +512,7 @@ TypeScript errors:
 ${TSC}"
             fi
             if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
-              BLOCKS=$(tail -n 50 "$OUTPUT")
+              BLOCKS="(no specific failure patterns matched — see full logs for details)"
             fi
             BLOCKS=$(echo "$BLOCKS" | head -c 5000)
           fi
@@ -651,7 +660,10 @@ ${TSC}"
         working-directory: meshery-cloud/ui
         env:
           ALLURE_RESULTS_DIR: ${{ github.workspace }}/meshery-cloud/ui/allure-results
-        run: npm run e2e 2>&1 | tee /tmp/e2e-output.txt
+        shell: bash
+        run: |
+          set -o pipefail
+          npm run e2e 2>&1 | tee /tmp/e2e-output.txt
 
       - name: Comment e2e success
         if: steps.e2e.outcome == 'success'
@@ -677,7 +689,7 @@ ${TSC}"
             BLOCKS=$(grep -E "✗|✘|×| FAILED |Error:|expect\\(received\\)" \
               "$OUTPUT" 2>/dev/null | head -50 || true)
             if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
-              BLOCKS=$(tail -n 50 "$OUTPUT")
+              BLOCKS="(no specific failure patterns matched — see full logs for details)"
             fi
             BLOCKS=$(echo "$BLOCKS" | head -c 5000)
           fi

--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -129,7 +129,7 @@ jobs:
         id: unit-tests
         continue-on-error: true
         working-directory: meshery-cloud
-        run: make server-tests-unit
+        run: make server-tests-unit 2>&1 | tee /tmp/unit-test-output.txt
 
       - name: Comment unit tests success
         if: steps.unit-tests.outcome == 'success'
@@ -143,6 +143,50 @@ jobs:
         with:
           id: cloud-tests
           message: ":x: Unit tests failed. Running integration tests..."
+
+      - name: Extract unit test failure details
+        if: steps.unit-tests.outcome == 'failure'
+        run: |
+          OUTPUT="/tmp/unit-test-output.txt"
+          if [ ! -f "$OUTPUT" ]; then
+            BLOCKS="(no output file found)"
+          else
+            # Extract Go "--- FAIL:" blocks with indented context lines
+            BLOCKS=$(awk '
+              /^--- FAIL:/ { in_fail=1; out=out"\n"$0; next }
+              in_fail && /^[[:space:]]/ { out=out"\n"$0; next }
+              in_fail { in_fail=0 }
+              /^FAIL[[:space:]]/ { out=out"\n"$0 }
+              END { print out }
+            ' "$OUTPUT" 2>/dev/null)
+            # Fallback: grep for error indicators
+            if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
+              BLOCKS=$(grep -E "^--- FAIL:|^FAIL[[:space:]]|Error:|panic:|cannot " "$OUTPUT" 2>/dev/null | head -40 || true)
+            fi
+            # Final fallback: last 50 lines
+            if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
+              BLOCKS=$(tail -n 50 "$OUTPUT")
+            fi
+            BLOCKS=$(echo "$BLOCKS" | head -c 5000)
+          fi
+          {
+            echo 'UNIT_FAILURES<<EOF_unit_9a8b7c'
+            echo "$BLOCKS"
+            echo 'EOF_unit_9a8b7c'
+          } >> "$GITHUB_ENV"
+      - name: Comment unit test failure details
+        if: steps.unit-tests.outcome == 'failure'
+        uses: ./.github/actions/cloud-comment
+        with:
+          id: cloud-tests
+          message: |
+            <details><summary>:mag: Server unit test failures</summary>
+
+            ```
+            ${{ env.UNIT_FAILURES }}
+            ```
+
+            </details>
       #------------------------------------------
 
       #------------------------------------------
@@ -151,7 +195,7 @@ jobs:
         continue-on-error: true
         if: ${{ inputs.run_integration_tests }}
         working-directory: meshery-cloud
-        run: make ENVIRONMENT=staging server-tests-integration
+        run: make ENVIRONMENT=staging server-tests-integration 2>&1 | tee /tmp/integration-test-output.txt
 
       - name: Comment integration tests success
         if: steps.integration-tests.outcome == 'success'
@@ -171,6 +215,47 @@ jobs:
         with:
           id: cloud-tests
           message: ":fast_forward: Integration tests skipped (not requested)."
+
+      - name: Extract integration test failure details
+        if: steps.integration-tests.outcome == 'failure'
+        run: |
+          OUTPUT="/tmp/integration-test-output.txt"
+          if [ ! -f "$OUTPUT" ]; then
+            BLOCKS="(no output file found)"
+          else
+            BLOCKS=$(awk '
+              /^--- FAIL:/ { in_fail=1; out=out"\n"$0; next }
+              in_fail && /^[[:space:]]/ { out=out"\n"$0; next }
+              in_fail { in_fail=0 }
+              /^FAIL[[:space:]]/ { out=out"\n"$0 }
+              END { print out }
+            ' "$OUTPUT" 2>/dev/null)
+            if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
+              BLOCKS=$(grep -E "^--- FAIL:|^FAIL[[:space:]]|Error:|panic:|cannot " "$OUTPUT" 2>/dev/null | head -40 || true)
+            fi
+            if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
+              BLOCKS=$(tail -n 50 "$OUTPUT")
+            fi
+            BLOCKS=$(echo "$BLOCKS" | head -c 5000)
+          fi
+          {
+            echo 'INTEGRATION_FAILURES<<EOF_int_9a8b7c'
+            echo "$BLOCKS"
+            echo 'EOF_int_9a8b7c'
+          } >> "$GITHUB_ENV"
+      - name: Comment integration test failure details
+        if: steps.integration-tests.outcome == 'failure'
+        uses: ./.github/actions/cloud-comment
+        with:
+          id: cloud-tests
+          message: |
+            <details><summary>:mag: Integration test failures</summary>
+
+            ```
+            ${{ env.INTEGRATION_FAILURES }}
+            ```
+
+            </details>
       #------------------------------------------
 
       #------------------------------------------
@@ -371,8 +456,9 @@ jobs:
       #------------------------------------------
       - name: Run UI tests
         id: ui-tests
+        continue-on-error: true
         working-directory: meshery-cloud
-        run: make ui-tests
+        run: make ui-tests 2>&1 | tee /tmp/ui-test-output.txt
 
       - name: Upload UI test results
         if: always()
@@ -395,6 +481,54 @@ jobs:
         with:
           id: cloud-ui-tests
           message: ":x: Cloud UI tests failed. See [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
+      - name: Extract UI test failure details
+        if: steps.ui-tests.outcome == 'failure'
+        run: |
+          OUTPUT="/tmp/ui-test-output.txt"
+          if [ ! -f "$OUTPUT" ]; then
+            BLOCKS="(no output file found)"
+          else
+            # Jest failures: FAIL file lines and ● bullet error descriptions
+            JEST=$(grep -E "^FAIL |^FAIL$|^ +● |^  ●|Tests:.*failed|Test Suites:.*failed|TypeError|ReferenceError" \
+              "$OUTPUT" 2>/dev/null | head -60 || true)
+            # TypeScript compiler errors (tsc --noEmit)
+            TSC=$(grep -E "\.tsx?:[0-9]+:[0-9]+ - error TS[0-9]+" \
+              "$OUTPUT" 2>/dev/null | head -20 || true)
+            BLOCKS=""
+            [ -n "$JEST" ] && BLOCKS="$JEST"
+            if [ -n "$TSC" ]; then
+              BLOCKS="${BLOCKS}
+TypeScript errors:
+${TSC}"
+            fi
+            if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
+              BLOCKS=$(tail -n 50 "$OUTPUT")
+            fi
+            BLOCKS=$(echo "$BLOCKS" | head -c 5000)
+          fi
+          {
+            echo 'UI_FAILURES<<EOF_ui_9a8b7c'
+            echo "$BLOCKS"
+            echo 'EOF_ui_9a8b7c'
+          } >> "$GITHUB_ENV"
+      - name: Comment UI test failure details
+        if: steps.ui-tests.outcome == 'failure'
+        uses: ./.github/actions/cloud-comment
+        with:
+          id: cloud-ui-tests
+          message: |
+            <details><summary>:mag: UI test failures</summary>
+
+            ```
+            ${{ env.UI_FAILURES }}
+            ```
+
+            </details>
+
+      - name: Fail UI tests job
+        if: steps.ui-tests.outcome == 'failure'
+        run: exit 1
       #------------------------------------------
 
       #------------------------------------------
@@ -517,7 +651,7 @@ jobs:
         working-directory: meshery-cloud/ui
         env:
           ALLURE_RESULTS_DIR: ${{ github.workspace }}/meshery-cloud/ui/allure-results
-        run: npm run e2e
+        run: npm run e2e 2>&1 | tee /tmp/e2e-output.txt
 
       - name: Comment e2e success
         if: steps.e2e.outcome == 'success'
@@ -531,6 +665,40 @@ jobs:
         with:
           id: cloud-e2e-tests
           message: ":x: Cloud Playwright e2e tests failed. See [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
+      - name: Extract e2e failure details
+        if: steps.e2e.outcome == 'failure'
+        run: |
+          OUTPUT="/tmp/e2e-output.txt"
+          if [ ! -f "$OUTPUT" ]; then
+            BLOCKS="(no output file found)"
+          else
+            # Playwright failure patterns: ✗/✘/× symbols, FAILED lines, errors
+            BLOCKS=$(grep -E "✗|✘|×| FAILED |Error:|expect\\(received\\)" \
+              "$OUTPUT" 2>/dev/null | head -50 || true)
+            if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
+              BLOCKS=$(tail -n 50 "$OUTPUT")
+            fi
+            BLOCKS=$(echo "$BLOCKS" | head -c 5000)
+          fi
+          {
+            echo 'E2E_FAILURES<<EOF_e2e_9a8b7c'
+            echo "$BLOCKS"
+            echo 'EOF_e2e_9a8b7c'
+          } >> "$GITHUB_ENV"
+      - name: Comment e2e failure details
+        if: steps.e2e.outcome == 'failure'
+        uses: ./.github/actions/cloud-comment
+        with:
+          id: cloud-e2e-tests
+          message: |
+            <details><summary>:mag: Playwright e2e failures</summary>
+
+            ```
+            ${{ env.E2E_FAILURES }}
+            ```
+
+            </details>
 
       - name: Upload e2e test results
         if: always()


### PR DESCRIPTION
## Summary

- **Capture test output** via `tee` for all three test jobs (server unit, server integration, UI/Jest, Playwright e2e), so the raw output is available for parsing even when tests fail.
- **Parse failure details** from the captured output:
  - Go tests: extracts `--- FAIL:` blocks with their indented context lines, plus package-level `FAIL` lines
  - Jest/UI tests: extracts `FAIL` file markers, `●` bullet test descriptions, `Tests: N failed` summary, and TypeScript compiler errors (`error TS…`)
  - Playwright e2e: extracts `✗`/`✘`/`×`/`FAILED` lines and `Error:` lines
  - All fallback to the last 50 lines of output if pattern matching yields nothing
- **Append failure details** to the running PR comment as a collapsed `<details>` block, so reviewers see which tests failed and why directly in the PR without navigating to workflow logs.
- **Fix `ui-tests` job**: the `Run UI tests` step was missing `continue-on-error: true`, which prevented the failure-comment and detail-extraction steps from running. Added `continue-on-error: true` and a matching `Fail UI tests job` gate step so the job still reports failure after comment/QA-sync steps complete.

## What the PR comment looks like on failure

Previously:
> ❌ Unit tests failed. Running integration tests...

After this change:
> ❌ Unit tests failed. Running integration tests...
> <details><summary>🔍 Server unit test failures</summary>
>
> ```
> --- FAIL: TestHandlerXxx (0.01s)
>     handler_test.go:123: Expected foo but got bar
> FAIL    github.com/layer5io/meshery-cloud/server/handlers
> ```
> </details>

## Test plan

- [ ] Trigger `meshery-cloud-on-pr.yml` against a meshery-cloud PR with known test failures and verify the failure details appear in the PR comment.
- [ ] Trigger against a passing PR and verify no spurious `<details>` blocks appear.
- [ ] Verify QA sync still runs after UI test failure (the `!cancelled()` condition on those steps is unchanged).
