### PR TITLE
fix(ci): repair YAML block-scalar break in cloud-test-reusable workflow

### DIFF
--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -507,9 +507,7 @@ jobs:
             BLOCKS=""
             [ -n "$JEST" ] && BLOCKS="$JEST"
             if [ -n "$TSC" ]; then
-              BLOCKS="${BLOCKS}
-TypeScript errors:
-${TSC}"
+              printf -v BLOCKS '%s\nTypeScript errors:\n%s' "$BLOCKS" "$TSC"
             fi
             if [ -z "$(echo "$BLOCKS" | tr -d '[:space:]')" ]; then
               BLOCKS="(no specific failure patterns matched — see full logs for details)"


### PR DESCRIPTION
## Problem

`meshery-cloud`'s `dispatch-remote-test` check has been failing with:

```
Dispatch failed (HTTP 422): Invalid Argument - failed to parse workflow: error parsing called workflow
-> "./.github/workflows/meshery-cloud-test-reusable.yml"
: You have an error in your yaml syntax on line 512
```

This blocks the remote integration test from even starting, and it reproduces for every meshery-cloud PR whose dispatch targets this workflow (observed failing on multiple open PRs).

## Root cause

The UI-failure-summary step assembled a multi-line shell string inside a `run: |` block:

```yaml
            if [ -n "$TSC" ]; then
              BLOCKS="${BLOCKS}
TypeScript errors:
${TSC}"
            fi
```

The continuation lines (`TypeScript errors:` and `${TSC}"`) sit at column 0 - **below** the literal block scalar's established indentation. YAML terminates the block scalar at the first under-indented line, then tries to parse `TypeScript errors:` as a new mapping key, which fails (`could not find expected ':'`).

## Fix

Replace the indentation-fragile multi-line assignment with a single-line `printf -v` that yields the identical value (`$BLOCKS` + newline + `TypeScript errors:` + newline + `$TSC`):

```yaml
            if [ -n "$TSC" ]; then
              printf -v BLOCKS '%s\nTypeScript errors:\n%s' "$BLOCKS" "$TSC"
            fi
```

This keeps the whole statement on one indented line, so the block scalar is no longer broken, and the emitted `UI_FAILURES` content is unchanged.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/meshery-cloud-test-reusable.yml'))"` → VALID (previously raised at line 512)
- Scanned all workflow files in `.github/workflows/` for the same block-scalar class of error - none remaining.