### PR TITLE
ci: update meshery-extensions source dir refs meshmap → ui

### DIFF
--- a/.github/workflows/build-extension-reusable.yml
+++ b/.github/workflows/build-extension-reusable.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           node-version: ${{ secrets.NODE_VERSION }}
           cache: "npm"
-          cache-dependency-path: 'meshery-extensions/meshmap/package-lock.json'
+          cache-dependency-path: 'meshery-extensions/ui/package-lock.json'
 
       - name: Verify go.mod sync compatibility
         working-directory: meshery-extensions

--- a/.github/workflows/bump-deps-meshery-and-extensions.yml
+++ b/.github/workflows/bump-deps-meshery-and-extensions.yml
@@ -103,7 +103,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: '**/package-lock.json'
       - name: Make changes to pull request
-        working-directory: meshmap
+        working-directory: ui
         run: npm install ${{github.event.inputs.dependencies}}@${{ github.event.inputs.version }}
       - name: Create Pull Request
         id: cpr
@@ -118,8 +118,8 @@ jobs:
           delete-branch: true
           title: '[Chore]: Bump ${{github.event.inputs.dependencies}} v${{ github.event.inputs.version }}'
           add-paths: |
-            meshmap/package.json
-            meshmap/package-lock.json
+            ui/package.json
+            ui/package-lock.json
           body: |
             Update to ${{github.event.inputs.dependencies}} v${{ github.event.inputs.version }}
             

--- a/.github/workflows/production-smoke-test-reusable.yml
+++ b/.github/workflows/production-smoke-test-reusable.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: "22.x"
           cache: "npm"
-          cache-dependency-path: 'meshery-extensions/meshmap/package-lock.json'
+          cache-dependency-path: 'meshery-extensions/ui/package-lock.json'
       - name: show tree
         run: tree  -L 2
       - name: Install Playwright dependencies
@@ -53,7 +53,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: meshery-extensions/meshmap/test-results/
+          path: meshery-extensions/tests/test-results/
           retention-days: 14
       - name: Send Email on Production Release Failure
         if: ${{ failure() }}

--- a/.github/workflows/production-smoke-test-reusable.yml
+++ b/.github/workflows/production-smoke-test-reusable.yml
@@ -52,7 +52,7 @@ jobs:
         id: test-results
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-test-results
           path: meshery-extensions/tests/test-results/
           retention-days: 14
       - name: Send Email on Production Release Failure


### PR DESCRIPTION
## What

Coordinates with layer5labs/meshery-extensions#4252, which renames the meshery-extensions React source directory `meshmap/` → `ui/`.

These workflows check out `layer5labs/meshery-extensions` and reference its source directory by path, so they must track the rename:

- `build-extension-reusable.yml` — `cache-dependency-path: 'meshery-extensions/ui/package-lock.json'`
- `production-smoke-test-reusable.yml` — `cache-dependency-path: 'meshery-extensions/ui/package-lock.json'`
- `bump-deps-meshery-and-extensions.yml` — `working-directory: ui` and `add-paths: ui/package*.json`

## Pre-existing bug fixed (drive-by)

`production-smoke-test-reusable.yml` uploaded the Playwright artifact from `meshery-extensions/meshmap/test-results/`, but Playwright runs via `cd tests; npx playwright test`, so its reporters write to `tests/test-results/` (confirmed by the custom reporter and `tests/strategy/TEST_STRATEGY.md`). `meshmap/test-results/` never existed. Corrected the path to `meshery-extensions/tests/test-results/` rather than propagate the broken path to `ui/`.

## Out of scope

The packages repo's own `/assets/meshmap` asset directory (animated GIFs / quick-tips, referenced by the Kanvas walkthrough) is unrelated to the meshery-extensions source dir and is intentionally left unchanged.

## Sequencing

Merge this PR first / in lockstep with meshery-extensions#4252. The reusable workflows here are `workflow_dispatch`/`release`-triggered (the auto-dispatcher is disabled), so neither repo's PR CI auto-builds the other; the merge window is safe.
