### PR TITLE
ci(kanvas): make extension release self-sufficient when extension tag lags core

### DIFF
--- a/.github/workflows/build-and-release-kanvas.yml
+++ b/.github/workflows/build-and-release-kanvas.yml
@@ -96,9 +96,45 @@ jobs:
         id: effective-release-values
         run: |
           echo "REVISION=$EXTENSION_REVISION" >> $GITHUB_OUTPUT
-      
-      - name: Re-checkout meshery-extensions at release tag
+
+      # The Kanvas package is the binding between three repos:
+      #   meshery/meshery@<MESHERY_VERSION>           (core platform - upstream, must already be tagged)
+      #   layer5labs/meshery-extensions@<LATEST_EXTENSION_VERSION>  (extension source - tagged by this workflow if needed)
+      #   meshery-extensions-packages release <LATEST_EXTENSION_VERSION> (this repo - tagged at publish time)
+      # All three must agree on the same version label so a downloaded provider-meshery.tar.gz
+      # is traceable to the exact source commits that produced it.
+      - name: Validate release refs and resolve extension checkout strategy
         if: ${{ inputs.version }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          EXTENSION_RELEASE_REF: ${{ env.LATEST_EXTENSION_VERSION }}
+          MESHERY_RELEASE_REF: ${{ env.MESHERY_VERSION }}
+        run: |
+          set -euo pipefail
+
+          # Core platform release MUST already exist - meshery/meshery is upstream of the
+          # extension package. If it is missing, cut the core release first.
+          if ! gh api "repos/meshery/meshery/git/refs/tags/${MESHERY_RELEASE_REF}" >/dev/null 2>&1; then
+            msg="Core platform tag '${MESHERY_RELEASE_REF}' does not exist in meshery/meshery. Cut the core release first, then re-run this workflow."
+            echo "reason=$msg" >> "$GITHUB_ENV"
+            echo "::error::$msg"
+            exit 1
+          fi
+
+          # Extension source tag - optional pre-existing tag:
+          #   exists -> re-checkout at it (deterministic, hotfix-safe).
+          #   missing -> build from the initial checkout; the publish step will create the
+          #              tag at that exact build commit (anchored via release-action's 'commit:').
+          if gh api "repos/layer5labs/meshery-extensions/git/refs/tags/${EXTENSION_RELEASE_REF}" >/dev/null 2>&1; then
+            echo "Extension tag '${EXTENSION_RELEASE_REF}' exists in layer5labs/meshery-extensions - re-checkout will use it."
+            echo "EXTENSION_TAG_EXISTS=true" >> "$GITHUB_ENV"
+          else
+            echo "::notice::Extension tag '${EXTENSION_RELEASE_REF}' does not exist yet in layer5labs/meshery-extensions. Building from the initial checkout; the publish step will create the tag at the build commit."
+            echo "EXTENSION_TAG_EXISTS=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Re-checkout meshery-extensions at release tag
+        if: ${{ inputs.version && env.EXTENSION_TAG_EXISTS == 'true' }}
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -106,6 +142,14 @@ jobs:
           path: "meshery-extensions"
           fetch-depth: 1
           ref: ${{ env.LATEST_EXTENSION_VERSION }}
+
+      - name: Capture extension build commit
+        working-directory: "meshery-extensions"
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse HEAD)
+          echo "EXTENSION_BUILD_SHA=$sha" >> "$GITHUB_ENV"
+          echo "Extension build commit: $sha"
 
       - name: Checkout meshery/meshery
         uses: actions/checkout@v6
@@ -201,6 +245,10 @@ jobs:
           repo: meshery-extensions
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           tag: ${{ env.LATEST_EXTENSION_VERSION }}
+          # Anchor the tag to the exact commit we built from. If the tag was created
+          # ahead of this workflow this is a no-op; if this workflow is creating the
+          # tag, this prevents drift if meshery-extensions master moves during the run.
+          commit: ${{ env.EXTENSION_BUILD_SHA }}
           name: Meshery Extensions ${{ env.LATEST_EXTENSION_VERSION }}
           allowUpdates: true
           artifactErrorsFailBuild: true


### PR DESCRIPTION
## Summary

The Kanvas release workflow assumed `layer5labs/meshery-extensions` had been pre-tagged at `<MESHERY_VERSION>-<REVISION>` before the workflow ran. When that pre-condition isn't met - as in run [26316568788](https://github.com/meshery-extensions/meshery-extensions-packages/actions/runs/26316568788/job/77476907551) where inputs were `version=v1.0.28, revision=1` but the extension repo is only tagged through `v1.0.22-1` - the re-checkout dies with a cryptic `git fetch ... +refs/tags/v1.0.28-1*` error before any compatibility validation runs.

This restores the **core ⇄ extension ⇄ package** commit/tag/package invariant in one workflow:

- `meshery/meshery@<MESHERY_VERSION>` (core platform - upstream, must already be tagged)
- `layer5labs/meshery-extensions@<LATEST_EXTENSION_VERSION>` (extension source - tagged by this workflow if needed)
- `meshery-extensions-packages` release `<LATEST_EXTENSION_VERSION>` (this repo - tagged at publish time)

All three agree on the same version label, and a downloaded `provider-meshery.tar.gz` is traceable to the exact source commits that produced it.

### What changed

- **New validation step** (`Validate release refs and resolve extension checkout strategy`):
  - Hard-fails with a clear `reason` (surfaced to the failure email) if `meshery/meshery` lacks the `MESHERY_VERSION` tag. Core is upstream and must be cut first.
  - Detects whether `layer5labs/meshery-extensions` already has the release tag; sets `EXTENSION_TAG_EXISTS` accordingly.
- **Re-checkout step is now conditional** on `EXTENSION_TAG_EXISTS == 'true'`. Tag exists -> deterministic build from that commit (hotfix-safe). Missing -> build from the initial branch checkout.
- **New `Capture extension build commit` step** records `EXTENSION_BUILD_SHA` from whichever checkout state we end in.
- **`publish stable release on meshery-extensions` now passes `commit: ${{ env.EXTENSION_BUILD_SHA }}`** to `ncipollo/release-action`. When this workflow creates the missing extension tag, it points at the exact commit we built - not wherever `master` happens to be at publish time. Tag-commit invariant holds even if `meshery-extensions/master` moves during the run.

### Symptom → Root cause → Fix → Watch for

- **Symptom** - Cryptic `git` fetch failure on `v1.0.28-1` in the re-checkout step.
- **Root cause** - Workflow assumed the extension tag was pre-created; no fallback when extension tagging lags core. Tag construction (`v1.0.28-1`) was already correct; the missing piece was the tag itself.
- **Fix** - Validate upstream, allow workflow to self-create the extension tag at the exact build commit, surface failures via the existing `reason` plumbing.
- **Watch for** - `update-extension-release.yaml` only updates `extension_releases.json` in meshery-extensions; it does not tag. Tag creation in `meshery-extensions` now happens authoritatively in this workflow. Other workflows touching meshery/meshery and layer5labs/meshery-extensions (`build-extension-reusable.yml`, `bump-deps-meshery-and-extensions.yml`, etc.) do not have a tag-pre-existence dependency, so this fix is scoped to the one place that needed it.

## Test plan

- [ ] YAML validated locally (`python3 -c 'import yaml; yaml.safe_load(open(...))'` passes)
- [ ] Re-run the failing dispatch with `version=v1.0.28, revision=1`:
  - [ ] Validation step passes (meshery v1.0.28 exists)
  - [ ] Validation step notices the extension tag is missing and proceeds
  - [ ] Build/compatibility checks run against initial master checkout
  - [ ] Publish creates `v1.0.28-1` in `layer5labs/meshery-extensions` at the exact `EXTENSION_BUILD_SHA`
  - [ ] Publish creates `v1.0.28-1` release in `meshery-extensions-packages` with `provider-meshery.tar.gz` attached
- [ ] Negative case: dispatch with a non-existent core version (e.g. `v9.9.9, 1`) - expect early failure with `reason` in the email
- [ ] Backward compat: dispatch with `version`+`revision` for a release tag that ALREADY exists - expect the deterministic re-checkout path to be taken (`EXTENSION_TAG_EXISTS=true`)