### PR TITLE
fix(workflow): target meshery-extensions in stable release step

### DIFF
--- a/.github/workflows/build-and-release-kanvas.yml
+++ b/.github/workflows/build-and-release-kanvas.yml
@@ -242,6 +242,11 @@ jobs:
       - name: publish stable release on meshery-extensions from tag
         uses: ncipollo/release-action@v1
         with:
+          # Extension source lives at layer5labs/meshery-extensions (see workflow header
+          # comment). 'owner' defaults to the current repo's owner (meshery-extensions),
+          # so it MUST be set explicitly here or the action targets
+          # meshery-extensions/meshery-extensions and 404s on list releases.
+          owner: layer5labs
           repo: meshery-extensions
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           tag: ${{ env.LATEST_EXTENSION_VERSION }}


### PR DESCRIPTION
## Symptom

`Build and Release Extensions` has failed on every run since `2026-05-19` at the step `publish stable release on meshery-extensions from tag`:

```
Error 404: Not Found - https://docs.github.com/rest/releases/releases#list-releases
Make sure your github token has access to the repo and has permission to author releases
```

Most recent failing run: https://github.com/meshery-extensions/meshery-extensions-packages/actions/runs/26559259082

## Root cause

[`ncipollo/release-action@v1`](https://github.com/ncipollo/release-action/blob/main/action.yml)'s `owner` input defaults to the current repo's owner:

```yaml
owner:
  description: "Optionally specify the owner of the repo where the release should be generated. Defaults to current repo's owner."
  required: false
  default: ''
```

Because the failing step sets `repo: meshery-extensions` but never sets `owner`, the action resolves the target to `meshery-extensions/meshery-extensions` - which does not exist. The extension source lives at `layer5labs/meshery-extensions`, as confirmed by:

- The workflow header comment: `layer5labs/meshery-extensions@<LATEST_EXTENSION_VERSION> (extension source - tagged by this workflow if needed)`
- `Checkout meshery-extensions`: `repository: layer5labs/meshery-extensions`
- `Validate release refs and resolve extension checkout strategy`: `gh api "repos/layer5labs/meshery-extensions/..."`
- `Re-checkout meshery-extensions at release tag`: `repository: layer5labs/meshery-extensions`
- `Get Meshery Extensions Release draft`: `curl ... https://api.github.com/repos/layer5labs/meshery-extensions/releases`

The publish step is the only one in the whole workflow that touches the extension source without pinning the owner.

The error message's `Make sure your github token has access to the repo` hint is misleading: the same `GH_ACCESS_TOKEN` successfully reads `layer5labs/meshery-extensions` in the four preceding steps of the same job. The 404 is on the target resolution, not on the token.

## Fix

Set `owner: layer5labs` on the failing step so the dispatch targets `layer5labs/meshery-extensions`, matching every other reference to the extension source in this workflow. Added a comment so the next person touching this step does not strip the owner under the assumption that the default is correct.

## Test plan

- [x] Verified `ncipollo/release-action@v1` (`v1` -> SHA `339a81892b84b4eeb0f6e744e4574d79d0d9b8dd`) defaults `owner` to the current repo's owner.
- [x] Verified `meshery-extensions/meshery-extensions` returns 404 (does not exist).
- [x] Verified `layer5labs/meshery-extensions` exists and is the source repo referenced by every other step.
- [x] Verified the preceding `publish stable release on meshery-extensions-packages from tag` step is correct as-is - it intentionally relies on the default owner (`meshery-extensions`) and targets `meshery-extensions/meshery-extensions-packages` (this repo). No change needed there.
- [ ] On merge, next dispatch should successfully create/update the release on `layer5labs/meshery-extensions`.

## Watch for

- No other step in this workflow uses `ncipollo/release-action` without an explicit `owner` alongside `repo`. The preceding `publish stable release on meshery-extensions-packages from tag` step targets the current repo correctly via the default owner.
- The `Send Email on Extensions Release Failure` step has been firing on every release for 9+ days. Whoever triages `support@layer5.io` should expect a noticeable backlog from this; the backlog will stop the next release after this PR merges.