### PR TITLE
fix(ci): replace NODE_VERSION required secret with vars.NODE_VERSION default

### DIFF
--- a/.github/workflows/build-extension-reusable.yml
+++ b/.github/workflows/build-extension-reusable.yml
@@ -14,8 +14,6 @@ on:
         required: false
         type: string
     secrets:
-      NODE_VERSION:
-        required: true
       GH_ACCESS_TOKEN:
         required: true
 
@@ -48,7 +46,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ secrets.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION || '22.x' }}
           cache: "npm"
           cache-dependency-path: 'meshery-extensions/ui/package-lock.json'
 

--- a/.github/workflows/extension-test-reusable.yml
+++ b/.github/workflows/extension-test-reusable.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: ${{ vars.NODE_VERSION || '22.x' }}
 
       # Moved up: checkout has no dependency on Kind/Docker and can
       # run while those slower steps proceed.


### PR DESCRIPTION
## Symptom
The `Meshery Extension Test on Release` workflow ([run 26658010148](https://github.com/meshery-extensions/meshery-extensions-packages/actions/runs/26658010148)) failed immediately at the `build-meshery-extension` call:

> Error when evaluating 'secrets'. `extension-test-reusable.yml` (Line: 63, Col: 11): Secret NODE_VERSION is required, but not provided while calling.

## Root cause
`build-extension-reusable.yml` declared `NODE_VERSION` as a **required secret**. No such secret exists in the repo/org, so `secrets: inherit` could not resolve it and GitHub aborted the call before any job ran. A Node version is not sensitive data - declaring it as a required secret is the wrong layer.

## Fix
- Remove the `NODE_VERSION` secret declaration from `build-extension-reusable.yml` and source the version via `vars.NODE_VERSION || '22.x'` - the same pattern already used in `meshery-cloud-on-pr.yml`. This removes the broken dependency and provides a safe default so the run never aborts on a missing secret again.
- Align the sibling `tests-ui-e2e` job in `extension-test-reusable.yml` (previously hardcoded `22.x`) to the same `vars.NODE_VERSION || '22.x'` source so both jobs in the chain agree on one source of truth.

## Watch for
Other reusable workflows that may declare non-secret config as required secrets. A repo/org variable `NODE_VERSION` can now be set to override the `22.x` default centrally.