### PR TITLE
ci(cloud): pass GIT_COMMITSHA to cloud builds so /api/system/version reports the deployed commit

### DIFF
--- a/.github/workflows/meshery-cloud-build-reusable.yml
+++ b/.github/workflows/meshery-cloud-build-reusable.yml
@@ -187,6 +187,7 @@ jobs:
           build-args: |
             ENVIRONMENT="staging"
             GIT_VERSION=staging-${{env.PR_NUMBER}}
+            GIT_COMMITSHA=${{ inputs.pr_commit_sha }}
             RELEASE_CHANNEL=staging
             TOKEN=${{ secrets.GLOBAL_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/meshery-cloud-release.yml
+++ b/.github/workflows/meshery-cloud-release.yml
@@ -128,6 +128,7 @@ jobs:
             echo "GIT_LATEST=${latest_version}"
             echo "GIT_VERSION=${git_version}"
             echo "GIT_STRIPPED_VERSION=${git_stripped_version}"
+            echo "GIT_COMMITSHA=$(git rev-parse HEAD)"
           } >> "$GITHUB_ENV"
 
           echo "Release channel determined to be ${release_channel}"
@@ -164,6 +165,7 @@ jobs:
           build-args: |
             ENVIRONMENT="stg"
             GIT_VERSION=${{inputs.release-environment}}-${{inputs.release-version}}
+            GIT_COMMITSHA=${{ env.GIT_COMMITSHA }}
             RELEASE_CHANNEL=${{inputs.release-environment}}
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
@@ -195,6 +197,10 @@ jobs:
         # Allow deploying from a configurable branch/tag (defaults to master) instead of the release version tag,
         # which may not exist yet when this workflow runs.
         ref: ${{ inputs.branch }}
+
+    - name: Capture Cloud commit SHA
+      working-directory: meshery-cloud
+      run: echo "GIT_COMMITSHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
     - name: Setup UI Dependencies
       working-directory: meshery-cloud
@@ -232,9 +238,10 @@ jobs:
         build-args: |
           ENVIRONMENT=prod
           GIT_VERSION=${{inputs.release-environment}}-${{inputs.release-version}}
+          GIT_COMMITSHA=${{ env.GIT_COMMITSHA }}
           RELEASE_CHANNEL=${{inputs.release-environment}}
           TOKEN=${{ secrets.GLOBAL_TOKEN }}
-        tags: ${{ steps.meta.outputs.tags }}s
+        tags: ${{ steps.meta.outputs.tags }}
         platforms: linux/amd64
     - name: Deploy production on bastion host
       uses: appleboy/ssh-action@master


### PR DESCRIPTION
## What

The cloud `/api/system/version` endpoint (`GitVersionHandler`) already emits a `commitsha` field when `GIT_COMMITSHA` is set, but the cloud image builds in this repo passed only `GIT_VERSION`. As a result deployed images report no commit sha:

- Staging: `{"version":"staging-<PR#>"}` — you can tell which PR is live but not which commit of it.
- Production: `{"version":"production-<tag>"}` — likewise no commit.

## Changes

- **`meshery-cloud-build-reusable.yml`** (staging PR build): pass the cloud PR head sha via the existing `inputs.pr_commit_sha`.
- **`meshery-cloud-release.yml`** (release builds): capture the checked-out cloud `HEAD` sha (`git rev-parse HEAD` in the `meshery-cloud` working dir) and pass it as `GIT_COMMITSHA` for both the staging-release and production builds.
- Drive-by: fixed a stray `s` appended to the production `tags:` expression (`}}s`), which corrupted the last computed image tag.

Mirrors the `--build-arg GIT_COMMITSHA=${GITHUB_SHA::8}` pattern already used by the meshery/kanvas playground build in this repo.

## Effect

After this merges, the next staging/PR and release builds will make `GET /api/system/version` return e.g. `{"version":"staging-5544","commitsha":"<sha>"}`, so you can confirm exactly which commit is deployed (useful for verifying a specific PR commit reached staging before running an e2e against it).

## Test plan
- [x] Both workflow files parse as valid YAML.
- [x] `inputs.pr_commit_sha` and `env.GIT_COMMITSHA` are confirmed in-scope at each build step.
- [ ] Runtime verification: confirm `commitsha` appears in `/api/system/version` after the next staging build (requires this to merge and a build to run).