### PR TITLE
[CI] Fix production Docker build failing with "No space left on device"

### DIFF
--- a/.github/workflows/meshery-cloud-release.yml
+++ b/.github/workflows/meshery-cloud-release.yml
@@ -202,12 +202,21 @@ jobs:
       working-directory: meshery-cloud
       run: echo "GIT_COMMITSHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
-    - name: Setup UI Dependencies
-      working-directory: meshery-cloud
-      run: make ui-setup
-    # - name: Build RTK Query Codegen
-    #   working-directory: meshery-cloud
-    #   run: make ui-api-codegen
+    # Reclaim disk on the hosted runner before the multi-stage image build.
+    # The prod image bundles a Go server, a Node/Next.js UI build, and academy
+    # content; without this the "Build and Push" step intermittently fails with
+    # "No space left on device" on the ~21 GB ubuntu-24.04 root filesystem.
+    #
+    # Note: the UI is compiled inside the Dockerfile's `node` stage (which runs
+    # its own `make ui-setup && make ui-build`), and `.dockerignore` excludes
+    # node_modules from the build context - so a host-side `make ui-setup` step
+    # here built nothing that reached the image and only consumed runner disk.
+    - name: Free up runner disk space
+      run: |
+        echo "Disk space before cleanup:"; df -h /
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+          /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/local/graalvm 2>/dev/null || true
+        echo "Disk space after cleanup:"; df -h /
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx


### PR DESCRIPTION
**Description**

Fixes the failing **`meshery-cloud-deploy / Production - Docker build and push`** job ([run 28813438048](https://github.com/meshery-extensions/meshery-extensions-packages/actions/runs/28813438048/job/85446830578)), which crashed the runner during the **Build and Push** step.

- **Symptom** - The job died with `System.IO.IOException: No space left on device`. The disk was so full the runner could not even write its own `_diag` worker log, so no step log was uploaded. The failure is intermittent (most production runs succeed in ~7-8 min).

- **Root cause** - The `prod` job ran a redundant host-side `make ui-setup` step (`cd ui; npm i`) before the Docker build. This writes ~1-2 GB of `node_modules` onto the runner for **zero benefit**:
  - The Dockerfile builds the UI inside its own `FROM node:20 AS ui` stage, which runs its own `make ui-setup && make ui-build`.
  - `meshery-cloud/.dockerignore` excludes `**/node_modules`, so the host copy never even entered the build context.

  That wasted disk pushed the multi-stage image build (Go server + Node/Next.js UI + academy content) over the ~21 GB `ubuntu-24.04` root filesystem. The working `staging` job builds *more* (linux/amd64 **and** linux/arm64) *without* this step.

- **Fix**
  1. Removed the redundant `Setup UI Dependencies` (`make ui-setup`) step, bringing the prod job in line with the passing staging job. Also removed its adjacent dead, commented-out RTK Query codegen step, which belonged to the same abandoned host-side-UI-prep approach.
  2. Added a `Free up runner disk space` step that reclaims ~15-20 GB of pre-installed toolchains this job never uses (Android SDK, .NET, GHC, CodeQL, Boost, GraalVM) - dependency-free, so no supply-chain surface added - giving comfortable headroom for a production-critical pipeline.

- **Watch for**
  - The `staging` job in the same file (linux/amd64 + linux/arm64) shares the same disk-pressure risk and would benefit from the same cleanup step if it ever starts failing; left untouched here to keep the change scoped to the reported failure.
  - Pre-existing `actionlint` warnings on lines 8/13 (`workflow_call` inputs marked `required: true` while also declaring a `default`) are unrelated to this failure and left as-is.

**Notes for Reviewers**

- Rebased onto current `master`. The `Capture Cloud commit SHA` step and the `GIT_COMMITSHA` build-args added by #726 are preserved untouched; the branch's diff is now a single, minimal change (the `ui-setup` -> disk-cleanup swap). The stray production `tags` `}}s` typo this branch originally also fixed was already fixed upstream by #726, so that change was dropped to avoid a conflicting duplicate.

- Runtime verification of the full job is not possible without dispatching a real production deploy (the job SSHes to the OCI bastion and `helm upgrade`s the prod cluster), so this was **not** run end-to-end. Verified statically:
  - `python3 -c "yaml.safe_load(...)"` - parses cleanly.
  - `actionlint` (with embedded shellcheck) - no new findings; the added `run:` block passes shellcheck.
  - Logic confirmed against the meshery-cloud `Dockerfile` (UI is built in-container) and `.dockerignore` (node_modules excluded from context).

  The fix will be exercised on the next production release dispatch.

**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
