### PR TITLE
fix(ci): stop QA sync from deleting published Allure results on empty runs

### DIFF
--- a/.github/workflows/extension-test-reusable.yml
+++ b/.github/workflows/extension-test-reusable.yml
@@ -437,15 +437,16 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           mkdir -p merged-allure-results
-          # Each shard may download with the original uploaded path preserved.
-          # Support both the nested artifact layout and the direct-root layout
-          # so the QA sync sees the full run without changing upload behavior.
-          for dir in \
-            shard-artifacts/playwright-artifacts-shard-*/meshery-extensions/tests/allure-results \
-            shard-artifacts/playwright-artifacts-shard-*/allure-results; do
-            [ -d "$dir" ] || continue
+          # Locate every shard's allure-results dir regardless of the layout the
+          # download step produces. Hardcoded globs broke silently when the
+          # upload/download-artifact actions were bumped (the new extraction
+          # layout no longer matched a fixed path prefix), which emptied the
+          # merge and - via the destructive sync below - deleted the published
+          # Kanvas results. `find` is layout-agnostic, matching the same
+          # robustness already used for shard-outcome discovery.
+          while IFS= read -r dir; do
             cp -R "$dir/." merged-allure-results/
-          done
+          done < <(find shard-artifacts -type d -name allure-results 2>/dev/null)
 
       # Master runs populate the canonical kanvas-results/ tree that feeds the
       # main qa.meshery.io dashboard. PR runs land under pr-reports/<N>/ so
@@ -460,13 +461,18 @@ jobs:
           else
             DEST="qa/kanvas-results"
           fi
-          rm -rf "$DEST"
-          mkdir -p "$DEST"
+          # Only wipe + replace the published results when THIS run produced
+          # some. Wiping unconditionally, then committing via git-auto-commit's
+          # file_pattern, turns an empty run into a commit that DELETES the last
+          # good report (this is exactly how kanvas-results was emptied). Leave
+          # the destination untouched when there is nothing to sync.
           if [ -d merged-allure-results ] && [ -n "$(ls -A merged-allure-results 2>/dev/null)" ]; then
+            rm -rf "$DEST"
+            mkdir -p "$DEST"
             cp -R merged-allure-results/. "$DEST/"
             echo "Synced $(find "$DEST" -type f | wc -l) file(s) to $DEST"
           else
-            echo "No merged-allure-results to sync"
+            echo "No merged-allure-results to sync; leaving $DEST intact"
           fi
 
       - name: Commit & push results to qa

--- a/.github/workflows/extension-test-reusable.yml
+++ b/.github/workflows/extension-test-reusable.yml
@@ -466,7 +466,7 @@ jobs:
           # file_pattern, turns an empty run into a commit that DELETES the last
           # good report (this is exactly how kanvas-results was emptied). Leave
           # the destination untouched when there is nothing to sync.
-          if [ -d merged-allure-results ] && [ -n "$(ls -A merged-allure-results 2>/dev/null)" ]; then
+          if [ -d merged-allure-results ] && [ -n "$(find merged-allure-results -type f -print -quit 2>/dev/null)" ]; then
             rm -rf "$DEST"
             mkdir -p "$DEST"
             cp -R merged-allure-results/. "$DEST/"

--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -319,7 +319,7 @@ jobs:
           for dir in \
             meshery-cloud/allure-results \
             meshery-cloud/server/*/allure-results; do
-            [ -d "$dir" ] && [ -n "$(ls -A "$dir" 2>/dev/null)" ] || continue
+            [ -d "$dir" ] && [ -n "$(find "$dir" -type f -print -quit 2>/dev/null)" ] || continue
             if [ "$synced" -eq 0 ]; then rm -rf "$SERVER_DEST"; mkdir -p "$SERVER_DEST"; synced=1; fi
             cp -R "$dir/." "$SERVER_DEST/" 2>/dev/null || true
           done
@@ -772,7 +772,7 @@ jobs:
           # emptied). Leave the destination intact when there is nothing to sync.
           synced=0
           for dir in meshery-cloud/ui/allure-results; do
-            [ -d "$dir" ] && [ -n "$(ls -A "$dir" 2>/dev/null)" ] || continue
+            [ -d "$dir" ] && [ -n "$(find "$dir" -type f -print -quit 2>/dev/null)" ] || continue
             if [ "$synced" -eq 0 ]; then rm -rf "$E2E_DEST"; mkdir -p "$E2E_DEST"; synced=1; fi
             cp -R "$dir/." "$E2E_DEST/" 2>/dev/null || true
           done

--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -311,15 +311,23 @@ jobs:
             BASE="qa"
           fi
           SERVER_DEST="$BASE/meshery-server-results"
-          rm -rf "$SERVER_DEST"
-          mkdir -p "$SERVER_DEST"
+          # Only wipe + replace when this run produced results; an unconditional
+          # rm -rf here would let an empty run commit a deletion of the published
+          # server results (same destructive-sync bug fixed for the e2e/Kanvas
+          # steps). Leave the destination intact when there is nothing to sync.
+          synced=0
           for dir in \
             meshery-cloud/allure-results \
             meshery-cloud/server/*/allure-results; do
-            [ -d "$dir" ] || continue
+            [ -d "$dir" ] && [ -n "$(ls -A "$dir" 2>/dev/null)" ] || continue
+            if [ "$synced" -eq 0 ]; then rm -rf "$SERVER_DEST"; mkdir -p "$SERVER_DEST"; synced=1; fi
             cp -R "$dir/." "$SERVER_DEST/" 2>/dev/null || true
           done
-          echo "meshery-server-results: $(find "$SERVER_DEST" -type f | wc -l) file(s)"
+          if [ "$synced" -eq 0 ]; then
+            echo "No server allure-results this run; leaving $SERVER_DEST intact"
+          else
+            echo "meshery-server-results: $(find "$SERVER_DEST" -type f | wc -l) file(s)"
+          fi
 
       - name: Commit & push server results to qa
         if: ${{ !cancelled() && steps.checkout-qa.outcome == 'success' }}
@@ -757,13 +765,22 @@ jobs:
             BASE="qa"
           fi
           E2E_DEST="$BASE/remote-provider-results"
-          rm -rf "$E2E_DEST"
-          mkdir -p "$E2E_DEST"
+          # Only wipe + replace the published results when this run produced
+          # some. An unconditional rm -rf here, committed via file_pattern below,
+          # turns an empty/cancelled e2e run into a commit that DELETES the last
+          # good Layer5 Cloud report (this is how remote-provider-results was
+          # emptied). Leave the destination intact when there is nothing to sync.
+          synced=0
           for dir in meshery-cloud/ui/allure-results; do
-            [ -d "$dir" ] || continue
+            [ -d "$dir" ] && [ -n "$(ls -A "$dir" 2>/dev/null)" ] || continue
+            if [ "$synced" -eq 0 ]; then rm -rf "$E2E_DEST"; mkdir -p "$E2E_DEST"; synced=1; fi
             cp -R "$dir/." "$E2E_DEST/" 2>/dev/null || true
           done
-          echo "remote-provider-results (e2e): $(find "$E2E_DEST" -type f | wc -l) file(s)"
+          if [ "$synced" -eq 0 ]; then
+            echo "No e2e allure-results this run; leaving $E2E_DEST intact"
+          else
+            echo "remote-provider-results (e2e): $(find "$E2E_DEST" -type f | wc -l) file(s)"
+          fi
 
       - name: Commit & push e2e results to qa
         if: ${{ !cancelled() && steps.checkout-qa.outcome == 'success' }}


### PR DESCRIPTION
## Problem

The **Extension: Kanvas** and **Extension: Remote Provider Layer5 Cloud** reports on
qa.meshery.io are blank. The cause is not that tests stopped running - the source-side QA sync
steps deleted the published results:

| Report | qa dir | Last real data | Last "sync" commit actually did |
|---|---|---|---|
| Kanvas | kanvas-results/ | 2026-07-13 | 955d4f1 deleted 1360 files, added 0 |
| Layer5 Cloud | remote-provider-results/ | 2026-04-23 | e13daf6 deleted 372 files, added 0 |

(meshery-results synced 2026-08-02, so this is source-specific, not a qa-wide issue.)

## Root cause

1. Destructive sync (both products). Each sync step ran `rm -rf "$DEST"` before checking whether
the run produced any Allure results, then committed via git-auto-commit's `file_pattern`. A run
that yields nothing therefore commits the deletion of every previously-published file. The two
"Sync..." commits above are pure deletions.

2. Kanvas merge glob broke on the artifact-action bump (the trigger). The Kanvas E2E tests still
run and still emit Allure results - the shard artifact from a recent run contains allure-results/
with 344 files. But the "Merge Allure results" step used hardcoded
`shard-artifacts/playwright-artifacts-shard-*/...` globs; after upload/download-artifact were
bumped to their latest majors (2026-07-11/14, matching the 07-13 last sync), the new extraction
layout no longer matched, so the merge came up empty - which then tripped bug 1 and deleted the
report.

## Fix

- Merge: discover allure-results with `find shard-artifacts -type d -name allure-results`
(layout-agnostic), matching the find-based robustness already used for shard-outcome discovery.
- Sync (Kanvas, Cloud e2e, Cloud server): only wipe + copy + commit when the run produced results;
otherwise leave the destination intact and commit nothing. Mirrors the qa repo Makefile
results-sync contract.

Once merged, a workflow_dispatch of extension-test.yml repopulates kanvas-results and the Kanvas
report refreshes.

## Out of scope (separate, deeper issue)

The Layer5 Cloud report will not refresh from this fix alone: meshery-cloud-test-reusable.yml
Playwright e2e is failing/cancelled before its sync step and its Allure reporters may not be wired
in meshery-cloud. That needs a meshery-cloud owner and is routed separately. This PR only stops the
destruction and restores the Kanvas path.

## Test plan

- [x] yaml.safe_load parses both workflows.
- [x] bash -n on the new merge/sync snippets.
- [ ] Post-merge: workflow_dispatch extension-test.yml; confirm the run logs "Synced N file(s)"
(not "No merged-allure-results"), a [Kanvas] Sync... commit that ADDS files lands on meshery/qa,
and the Kanvas report on qa.meshery.io repopulates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QA result handling across test workflows.
  * Results are now discovered from nested artifact layouts.
  * Previously published results are preserved when a test run produces no results.
  * Existing results are replaced only when new, non-empty results are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->