### PR TITLE
[CI] Publish Layer5 Cloud e2e Allure results to qa (project label + step<job timeout)

### DIFF
--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -606,7 +606,11 @@ jobs:
   e2e-tests:
     name: Playwright e2e
     runs-on: ubuntu-24.04
-    timeout-minutes: 55
+    # e2e is a long, serial (workers:1) suite (~240 tests). Keep the job ceiling
+    # generous so a full run can finish and go green; the test step below uses a
+    # smaller timeout so an overrun still leaves the job alive to run the QA sync
+    # + gating steps rather than being cancelled with nothing published.
+    timeout-minutes: 85
     env:
       GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       PR_NUMBER: ${{ inputs.pr_number }}
@@ -657,19 +661,28 @@ jobs:
         working-directory: meshery-cloud/ui
         run: npx playwright install --with-deps
 
-      # ALLURE_RESULTS_DIR routes allure-playwright (when wired in
-      # meshery-cloud) to a path the sync-to-qa step collects. Until that
-      # reporter is added, the directory stays empty and sync no-ops.
-      # Step timeout is set below the job timeout so a hung test fails
-      # with room left for the QA sync + gating step to run. Current
-      # observed e2e runtime is ~22 min; 25 min gives a small buffer.
+      # allure-playwright (wired in meshery-cloud/ui/playwright.config.ts) writes
+      # per-test Allure results to ALLURE_RESULTS_DIR, which the sync-to-qa step
+      # below collects. ALLURE_LABEL_* are read by allure-js-commons and stamped
+      # on every result as global labels: project=Layer5Cloud is the label the
+      # qa.meshery.io "Remote Provider Layer5 Cloud" report filters on (see
+      # meshery/qa allurerc.mjs), mirroring how the Kanvas lane sets
+      # ALLURE_LABEL_project=Kanvas.
+      #
+      # The step timeout is kept BELOW the job timeout so that when the suite
+      # overruns, only the test step is killed (continue-on-error) while the job
+      # keeps running - the QA sync + gating steps still execute and publish the
+      # results produced so far, instead of the whole job being cancelled with
+      # nothing synced.
       - name: Run Cloud UI e2e tests
         id: e2e
-        timeout-minutes: 55
+        timeout-minutes: 75
         continue-on-error: true
         working-directory: meshery-cloud/ui
         env:
           ALLURE_RESULTS_DIR: ${{ github.workspace }}/meshery-cloud/ui/allure-results
+          ALLURE_LABEL_project: Layer5Cloud
+          ALLURE_LABEL_type: e2e
         shell: bash
         run: |
           set -o pipefail

--- a/.github/workflows/meshery-cloud-test-reusable.yml
+++ b/.github/workflows/meshery-cloud-test-reusable.yml
@@ -661,9 +661,12 @@ jobs:
         working-directory: meshery-cloud/ui
         run: npx playwright install --with-deps
 
-      # allure-playwright (wired in meshery-cloud/ui/playwright.config.ts) writes
-      # per-test Allure results to ALLURE_RESULTS_DIR, which the sync-to-qa step
-      # below collects. ALLURE_LABEL_* are read by allure-js-commons and stamped
+      # allure-playwright (wired in meshery-cloud/ui/playwright.config.ts by
+      # layer5io/meshery-cloud#5846) writes per-test Allure results to
+      # ALLURE_RESULTS_DIR, which the sync-to-qa step below collects. Until that
+      # companion PR lands the reporter is absent, the results dir stays empty,
+      # and the non-empty-guarded sync simply no-ops - this step is safe either
+      # way. ALLURE_LABEL_* are read by allure-js-commons and stamped
       # on every result as global labels: project=Layer5Cloud is the label the
       # qa.meshery.io "Remote Provider Layer5 Cloud" report filters on (see
       # meshery/qa allurerc.mjs), mirroring how the Kanvas lane sets


### PR DESCRIPTION
## Problem

The **Extension: Remote Provider Layer5 Cloud** report on qa.meshery.io is empty and cannot repopulate from the Cloud e2e lane, for two reasons in this workflow:

1. **No project label.** The qa dashboard's [`allurerc.mjs`](https://github.com/meshery/qa/blob/master/allurerc.mjs) builds each report by filtering results on an Allure `project` label (`project==Layer5Cloud`). The e2e step never set it, so even once results are emitted they would not land in the Layer5 Cloud report. (The Kanvas lane sets `ALLURE_LABEL_project=Kanvas` the same way.)
2. **Job cancelled before sync.** The e2e job timeout and the e2e step timeout were both `55m`, but the ~240-test, single-worker suite runs ~68m. The **job** timeout therefore fired first and cancelled the whole job, so every `if: !cancelled()` step - the QA sync and the gate - was skipped and nothing published. The step's own comment already documents the intended design (step timeout below job timeout so an overrun still leaves room to sync); the values had drifted to equal.

## Fix

- Export `ALLURE_LABEL_project=Layer5Cloud` and `ALLURE_LABEL_type=e2e` on the `Run Cloud UI e2e tests` step.
- Restore the step<job margin and give the suite room: job timeout `55 -> 85`, e2e step timeout `55 -> 75`. The full suite now fits (goes green when tests pass); on an overrun only the step is killed (`continue-on-error`) while the job stays alive to run the sync + gate, publishing whatever ran.

## Dependency

The `project` label is only useful once results exist. The companion PR [layer5io/meshery-cloud#5846](https://github.com/layer5io/meshery-cloud/pull/5846) wires the `allure-playwright` reporter (which writes to the `ALLURE_RESULTS_DIR` this workflow already exports). Both together repopulate the report; this PR is safe to land on its own (the label env and non-empty-guarded sync are no-ops until results are emitted).

## Validation

`yaml.safe_load` on the workflow. Label routing verified against `allurerc.mjs` and confirmed on the meshery-cloud side (a smoke spec emits a result carrying `project=Layer5Cloud`).

## Out of scope (flagged)

- The recurring `l5io` `workflow_dispatch` storm and some genuinely failing e2e specs are tracked separately; neither is required for the report to repopulate.
